### PR TITLE
refactor: emit options used to create a `Party`

### DIFF
--- a/contracts/party/IPartyFactory.sol
+++ b/contracts/party/IPartyFactory.sol
@@ -9,7 +9,13 @@ import "./Party.sol";
 
 // Creates generic Party instances.
 interface IPartyFactory {
-    event PartyCreated(Party party, Party.PartyOptions opts, address creator);
+    event PartyCreated(
+        Party party,
+        Party.PartyOptions opts,
+        IERC721[] preciousTokens,
+        uint256[] preciousTokenIds,
+        address creator
+    );
 
     /// @notice Deploy a new party instance. Afterwards, governance NFTs can be minted
     ///         for party members using the `mint()` function from the newly

--- a/contracts/party/PartyFactory.sol
+++ b/contracts/party/PartyFactory.sol
@@ -50,6 +50,6 @@ contract PartyFactory is IPartyFactory {
                 abi.encodeCall(Party.initialize, (initData))
             )
         ));
-        emit PartyCreated(party, opts, msg.sender);
+        emit PartyCreated(party, opts, preciousTokens, preciousTokenIds, msg.sender);
     }
 }

--- a/contracts/party/PartyGovernance.sol
+++ b/contracts/party/PartyGovernance.sol
@@ -160,7 +160,6 @@ abstract contract PartyGovernance is
         uint256 weight
     );
 
-    event PartyInitialized(GovernanceOpts opts, IERC721[] preciousTokens, uint256[] preciousTokenIds);
     event ProposalPassed(uint256 indexed proposalId);
     event ProposalVetoed(uint256 indexed proposalId, address host);
     event ProposalExecuted(uint256 indexed proposalId, address executor, bytes nextProgressData);
@@ -307,7 +306,6 @@ abstract contract PartyGovernance is
         for (uint256 i=0; i < opts.hosts.length; ++i) {
             isHost[opts.hosts[i]] = true;
         }
-        emit PartyInitialized(opts, preciousTokens, preciousTokenIds);
     }
 
     /// @dev Forward all unknown read-only calls to the proposal execution engine.


### PR DESCRIPTION
We emit the options that are used to create crowdfunds, but not for creating parties. Since parties can be created outside the conventional flow and don't always start at the crowdfund stage, we should emit the options (eg. `name` and `symbol`) that were used to create them as well.