### PR TITLE
fix(): update goerli zone to null zone

### DIFF
--- a/deploy/LibDeployConstants.sol
+++ b/deploy/LibDeployConstants.sol
@@ -56,7 +56,7 @@ library LibDeployConstants {
       zoraMaxAuctionTimeout: 7 days,
       partyDaoMultisig: multisig,
       zoraAuctionHouseAddress: 0x6a6Cdb103f1072E0aFeADAC9BeBD6E14B287Ca57,
-      osZone: 0x00000000E88FE2628EbC5DA81d2b3CeaD633E89e,
+      osZone: 0x0000000000000000000000000000000000000000,
       osConduitKey: 0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000,
       osConduitController: 0x00000000F9490004C11Cef243f5400493c00Ad63,
       networkName: 'goerli',


### PR DESCRIPTION
change goerli deploy constants to use null zone for opensea zone

order type for null zone is handled here: https://github.com/PartyDAO/partybidV2/blob/main/contracts/proposals/ListOnOpenseaProposal.sol#L252-L254