### PR TITLE
fix(`ArbitraryCallsProposal`): disallow calls on receive hooks

### DIFF
--- a/contracts/proposals/ArbitraryCallsProposal.sol
+++ b/contracts/proposals/ArbitraryCallsProposal.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8;
 
 import "../tokens/IERC721.sol";
 import "../tokens/IERC721Receiver.sol";
+import "../tokens/ERC1155Receiver.sol";
 import "../utils/LibSafeERC721.sol";
 
 import "./LibProposal.sol";
@@ -191,8 +192,12 @@ contract ArbitraryCallsProposal {
                     }
                 }
             }
-            // Can never call `onERC721Received()` on any target.
-            if (selector == IERC721Receiver.onERC721Received.selector) {
+            // Can never call receive hooks on any target.
+            if (
+                selector == IERC721Receiver.onERC721Received.selector ||
+                selector == ERC1155TokenReceiverBase.onERC1155Received.selector ||
+                selector == ERC1155TokenReceiverBase.onERC1155BatchReceived.selector
+            ) {
                return false;
            }
         }

--- a/sol-tests/proposals/ArbitraryCallsProposal.t.sol
+++ b/sol-tests/proposals/ArbitraryCallsProposal.t.sol
@@ -521,6 +521,44 @@ contract ArbitraryCallsProposalTest is
         testContract.execute(prop);
     }
 
+    function test_cannotCallOnERC1155Received() external {
+        (
+            ArbitraryCallsProposal.ArbitraryCall[] memory calls,
+        ) = _createSimpleCalls(1, false);
+        calls[0].target = _randomAddress();
+        calls[0].data = abi.encodeCall(
+            ERC1155TokenReceiverBase.onERC1155Received,
+            (_randomAddress(), _randomAddress(), _randomUint256(), _randomUint256(), bytes(''))
+        );
+        IProposalExecutionEngine.ExecuteProposalParams memory prop =
+            _createTestProposal(calls);
+        vm.expectRevert(abi.encodeWithSelector(
+            ArbitraryCallsProposal.CallProhibitedError.selector,
+            calls[0].target,
+            calls[0].data
+        ));
+        testContract.execute(prop);
+    }
+
+    function test_cannotCallOnERC1155BatchReceived() external {
+        (
+            ArbitraryCallsProposal.ArbitraryCall[] memory calls,
+        ) = _createSimpleCalls(1, false);
+        calls[0].target = _randomAddress();
+        calls[0].data = abi.encodeCall(
+            ERC1155TokenReceiverBase.onERC1155BatchReceived,
+            (_randomAddress(), _randomAddress(), _toUint256Array(0), _toUint256Array(0), bytes(''))
+        );
+        IProposalExecutionEngine.ExecuteProposalParams memory prop =
+            _createTestProposal(calls);
+        vm.expectRevert(abi.encodeWithSelector(
+            ArbitraryCallsProposal.CallProhibitedError.selector,
+            calls[0].target,
+            calls[0].data
+        ));
+        testContract.execute(prop);
+    }
+
     function test_cannotExecuteShortApproveCallData() external {
         (
             ArbitraryCallsProposal.ArbitraryCall[] memory calls,


### PR DESCRIPTION
**Related Issue:** [ArbitraryCallsProposal: onERC1155Received callable](https://github.com/code-423n4/2022-09-party-findings/issues/108)