### PR TITLE
feat(distributor): add reentrancy guard

### DIFF
--- a/contracts/distribution/TokenDistributor.sol
+++ b/contracts/distribution/TokenDistributor.sol
@@ -380,7 +380,15 @@ contract TokenDistributor is ITokenDistributor {
         bytes32 balanceId = _getBalanceId(tokenType, token);
         // Reduce stored token balance.
         uint256 storedBalance = _storedBalances[balanceId] - amount;
-        // Temporarily set to max as a reentrancy guard.
+        // Temporarily set to max as a reentrancy guard. An interesing attack
+        // could occur if we didn't do this where an attacker could `claim()` and
+        // reenter upon transfer (eg. in the `tokensToSend` hook of an ERC777) to
+        // `createERC20Distribution()`. Since the `balanceOf(address(this))`
+        // would not of been updated yet, the supply would be miscalculated and
+        // the attacker would create a distribution that essentially steals from
+        // the last distribution they were claiming from. Here, we prevent that
+        // by causing an arithmetic underflow with the supply calculation if
+        // this were to be attempted.
         _storedBalances[balanceId] = type(uint256).max;
         if (tokenType == TokenType.Native) {
             recipient.transferEth(amount);

--- a/sol-tests/distribution/TokenDistributorUnit.t.sol
+++ b/sol-tests/distribution/TokenDistributorUnit.t.sol
@@ -60,7 +60,12 @@ contract ReenteringToken is ERC20("ReenteringToken", "RET", 18) {
     }
 
     function transfer(address to, uint256 amount) public virtual override returns (bool) {
-        // Reenter into distributor to create another ERC20 distribution.
+        // Reenter into distributor to create another ERC20 distribution. Mimics
+        // how ERC777 tokens will call a `tokensToSend` hook on transfer which
+        // can implement arbitrary logic. Here, we use it to create a new
+        // distribution before the state update triggered by another claiming
+        // from distribution (which this is attempting to steal from) has been
+        // updated.
         distributor.createErc20Distribution(
             IERC20(address(this)),
             ITokenDistributorParty(address(0)),


### PR DESCRIPTION
**Related Issue:** [TokenDistributor: ERC777 tokensToSend hook can be exploited to drain contract](https://github.com/code-423n4/2022-09-party-findings/issues/120)