### PR TITLE
fix(`ArbitraryCallsProposal`): disallow calls to `OS.validate()`

### DIFF
--- a/contracts/proposals/ArbitraryCallsProposal.sol
+++ b/contracts/proposals/ArbitraryCallsProposal.sol
@@ -7,6 +7,7 @@ import "../tokens/IERC721Receiver.sol";
 import "../tokens/ERC1155Receiver.sol";
 import "../utils/LibSafeERC721.sol";
 import "../utils/LibAddress.sol";
+import "./vendor/IOpenseaExchange.sol";
 
 import "./LibProposal.sol";
 import "./IProposalExecutionEngine.sol";
@@ -205,7 +206,11 @@ contract ArbitraryCallsProposal {
                 selector == ERC1155TokenReceiverBase.onERC1155BatchReceived.selector
             ) {
                return false;
-           }
+            }
+            // Disallow calling `validate()` on Seaport.
+            if (selector == IOpenseaExchange.validate.selector) {
+                return false;
+            }
         }
         // All other calls are allowed.
         return true;

--- a/sol-tests/proposals/OpenseaTestUtils.sol
+++ b/sol-tests/proposals/OpenseaTestUtils.sol
@@ -69,7 +69,7 @@ contract OpenseaTestUtils is Test {
         uint256[] memory fees,
         address payable[] memory feeRecipients
     )
-        private
+        internal
         pure
         returns (IOpenseaExchange.Order memory order)
     {
@@ -105,5 +105,17 @@ contract OpenseaTestUtils is Test {
         order.parameters.totalOriginalConsiderationItems = 1 + fees.length;
         order.parameters.conduitKey = params.conduitKey;
         order.parameters.zone = params.zone;
+    }
+
+    function _createFullOpenseaOrderParams(BuyOpenseaListingParams memory params)
+        internal
+        pure
+        returns (IOpenseaExchange.Order memory order)
+    {
+        return _createFullOpenseaOrderParams(
+            params,
+            new uint256[](0),
+            new address payable[](0)
+        );
     }
 }


### PR DESCRIPTION
Related: [ArbitraryCallsProposal.sol and ListOnOpenseaProposal.sol safeguards can be bypassed by cancelling in-progress proposal allowing the majority to steal NFT](https://github.com/code-423n4/2022-09-party-findings/issues/153)