### PR TITLE
fix majority attack when zora proposal cancelled

### DIFF
--- a/contracts/proposals/ProposalExecutionEngine.sol
+++ b/contracts/proposals/ProposalExecutionEngine.sol
@@ -88,6 +88,7 @@ contract ProposalExecutionEngine is
         ListOnOpenseaProposal(globals, seaport, seaportConduitController)
         ListOnZoraProposal(globals, zoraAuctionHouse)
         FractionalizeProposal(fractionalVaultFactory)
+        ArbitraryCallsProposal(zoraAuctionHouse)
     {
         _GLOBALS = globals;
     }

--- a/sol-tests/crowdfund/Crowdfund.t.sol
+++ b/sol-tests/crowdfund/Crowdfund.t.sol
@@ -1022,7 +1022,6 @@ contract CrowdfundTest is Test, TestUtils {
     function test_canReuseContributionEntry() external {
         TestableCrowdfund cf = _createCrowdfund(0);
         address contributor = _randomAddress();
-        address payable badERC721Receiver = payable(new BadERC721Receiver());
         // Contributor contributes twice back-to-back.
         vm.deal(contributor, 3);
         vm.prank(contributor);
@@ -1039,7 +1038,6 @@ contract CrowdfundTest is Test, TestUtils {
         TestableCrowdfund cf = _createCrowdfund(0);
         address contributor1 = _randomAddress();
         address contributor2 = _randomAddress();
-        address payable badERC721Receiver = payable(new BadERC721Receiver());
         // contributor1 sandwiches contributor2.
         vm.deal(contributor1, 3);
         vm.deal(contributor2, 10);


### PR DESCRIPTION
Attack rundown:
- List on zora (precious xferred to zora).
- Cancel proposal (precious still in zora).
- Execute arbitrary calls:
  - Call `zora.cancelAuction()` -> xfer precious back to party
  - call `precious.transferFrom()` -> xfer to attacker

Works because we only check if an we lost an NFT if we had it before executing arb calls.

Proposed solution is to just prevent arbitrary calls `zora.cancelAuction()` *unless* it's the last call in the arb calls sequence.

  