### PR TITLE
feat(renderer): always render `tokenURI` with 3 digits

### DIFF
--- a/contracts/renderers/CrowdfundNFTRenderer.sol
+++ b/contracts/renderers/CrowdfundNFTRenderer.sol
@@ -228,7 +228,7 @@ contract CrowdfundNFTRenderer is RendererBase {
 
     function getContribution(address owner) private view returns (string memory amount) {
         (uint256 ethContributed, , ,) = Crowdfund(address(this)).getContributorInfo(owner);
-        return formatAsDecimalString(ethContributed, 18);
+        return formatAsDecimalString(ethContributed, 18, 4);
     }
 
     function getCrowdfundStatus() private view returns (CrowdfundStatus) {

--- a/contracts/renderers/PartyNFTRenderer.sol
+++ b/contracts/renderers/PartyNFTRenderer.sol
@@ -246,15 +246,6 @@ contract PartyNFTRenderer is RendererBase {
     }
 
     function generateSVG5(bool hasUnclaimed, uint256 tokenId, Color color) private view returns (string memory) {
-        // Render token ID always with 3 digits.
-        string memory id = tokenId.toString();
-        uint256 len = bytes(id).length;
-        if (len < 3) {
-            for (uint256 i; i < 3 - len; ++i) {
-                id = string.concat("0", id);
-            }
-        }
-
         return string.concat(
             '"',
             _storage.readFile(PARTY_CARD_DATA),
@@ -269,7 +260,8 @@ contract PartyNFTRenderer is RendererBase {
             '"/></g><rect height="345" rx="15" ry="15" style="fill:url(#i)" width="330" x="15" y="180"/><text text-anchor="middle" style="font-family:ui-monospace,Cascadia Mono,Menlo,Monaco,Segoe UI Mono,Roboto Mono,Oxygen Mono,Ubuntu Monospace,Source Code Pro,Droid Sans Mono,Fira Mono,Courier,monospace;fill:',
             generateColorHex(color, ColorType.PRIMARY),
             ';font-weight:500;" x="307.5" y="156">',
-            id,
+            // Always render token ID with 3 digits.
+            prependNumWithZeros(tokenId.toString(), 3),
             '</text></svg>'
         );
     }
@@ -301,8 +293,10 @@ contract PartyNFTRenderer is RendererBase {
         uint256 intrinsicVotingPowerPercentage = PartyGovernance(address(this)).getDistributionShareOf(tokenId);
         if (intrinsicVotingPowerPercentage == 1e18) {
             return "100";
+        } else if (intrinsicVotingPowerPercentage < 0.1e18) {
+            return formatAsDecimalString(intrinsicVotingPowerPercentage, 16, 3);
         } else {
-            return formatAsDecimalString(intrinsicVotingPowerPercentage, 16);
+            return formatAsDecimalString(intrinsicVotingPowerPercentage, 16, 4);
         }
     }
 

--- a/contracts/renderers/RendererBase.sol
+++ b/contracts/renderers/RendererBase.sol
@@ -257,7 +257,7 @@ abstract contract RendererBase is IERC721Renderer {
         }
     }
 
-    function formatAsDecimalString(uint256 n, uint256 decimals) internal pure returns (string memory) {
+    function formatAsDecimalString(uint256 n, uint256 decimals, uint256 maxChars) internal pure returns (string memory) {
         string memory str = n.toString();
         uint256 oneUnit = 10**decimals;
         if (n < 10**(decimals - 2)) {
@@ -265,16 +265,23 @@ abstract contract RendererBase is IERC721Renderer {
         } else if (n < oneUnit) {
             // Preserve leading zeros for decimals.
             // (eg. if 0.01, `n` will "1" so we need to prepend a "0").
-            uint256 len = bytes(str).length;
-            for (uint256 i; i < decimals - len; ++i) {
-                str = string.concat("0", str);
-            }
-            return string.concat("0.", str.substring(0, 4 - 1));
+            return string.concat("0.", prependNumWithZeros(str, decimals).substring(0, maxChars - 1));
         } else if (n >= 1000 * oneUnit) {
-            return str.substring(0, 4);
+            return str.substring(0, maxChars);
         } else {
             uint256 i = bytes((n / oneUnit).toString()).length;
-            return string.concat(str.substring(0, i), ".", str.substring(i, 4));
+            return string.concat(str.substring(0, i), ".", str.substring(i, maxChars));
         }
+    }
+
+    function prependNumWithZeros(string memory numStr, uint256 expectedLength) internal pure returns (string memory) {
+        uint256 length = bytes(numStr).length;
+        if (length < expectedLength) {
+            for (uint256 i; i < expectedLength - length; ++i) {
+                numStr = string.concat("0", numStr);
+            }
+        }
+
+        return numStr;
     }
 }

--- a/sol-tests/party/PartyGovernanceNFT.t.sol
+++ b/sol-tests/party/PartyGovernanceNFT.t.sol
@@ -231,8 +231,11 @@ contract PartyGovernanceNFTTest is Test, TestUtils {
         party.createMockProposal(PartyGovernance.ProposalStatus.InProgress);
 
         // Mint governance NFT
-        uint256 tokenId = 1;
+        uint256 tokenId = 396;
         party.mint(tokenId);
+
+        // Set voting power percentage
+        party.setVotingPowerPercentage(0.42069e18);
 
         // Set claimed/unclaimed state
         tokenDistributor.setHasClaimed(address(party), false);
@@ -271,6 +274,9 @@ contract PartyGovernanceNFTTest is Test, TestUtils {
         uint256 tokenId = 396;
         party.mint(tokenId);
 
+        // Set voting power percentage
+        party.setVotingPowerPercentage(0.42069e18);
+
         // Set claimed/unclaimed state
         tokenDistributor.setHasClaimed(address(party), false);
 
@@ -299,6 +305,9 @@ contract PartyGovernanceNFTTest is Test, TestUtils {
         // Mint governance NFT
         uint256 tokenId = 396;
         party.mint(tokenId);
+
+        // Set voting power percentage
+        party.setVotingPowerPercentage(0.42069e18);
 
         // Set claimed/unclaimed state
         tokenDistributor.setHasClaimed(address(party), false);
@@ -384,6 +393,7 @@ contract DummyParty is ReadOnlyDelegateCall {
     mapping(uint256 => uint256) public votingPowerByTokenId;
 
     mapping(uint256 => PartyGovernance.ProposalStatus) _proposalStatuses;
+    uint256 votingPowerPercentage; // 1e18 == 100%
 
     function useCustomizationPreset(uint256 customizationPresetId) external {
         if (customizationPresetId != 0) {
@@ -422,8 +432,12 @@ contract DummyParty is ReadOnlyDelegateCall {
         values;
     }
 
-    function getDistributionShareOf(uint256) external pure returns (uint256) {
-        return 0.42069e18;
+    function setVotingPowerPercentage(uint256 vp) external {
+        votingPowerPercentage = vp;
+    }
+
+    function getDistributionShareOf(uint256) external view returns (uint256) {
+        return votingPowerPercentage;
     }
 
     function _delegateToRenderer() private view {


### PR DESCRIPTION
For a `tokenURI` < 100, will pad with "0"s until it is 3 digits.

![party-card](https://user-images.githubusercontent.com/20782088/199656742-dd00e568-e301-413d-82f0-3546c5715764.svg)
