### PR TITLE
feat: support ENS domains for crowdfunds and parties

### DIFF
--- a/contracts/crowdfund/AuctionCrowdfund.sol
+++ b/contracts/crowdfund/AuctionCrowdfund.sol
@@ -73,6 +73,8 @@ contract AuctionCrowdfund is Crowdfund {
         // Fixed governance options (i.e. cannot be changed) that the governance
         // `Party` will be created with if the crowdfund succeeds.
         FixedGovernanceOpts governanceOpts;
+        // Optional ENS domain name options to use for the crowdfund and party.
+        ENS ens;
     }
 
     event Bid(uint256 bidAmount);
@@ -137,7 +139,8 @@ contract AuctionCrowdfund is Crowdfund {
                 initialDelegate: opts.initialDelegate,
                 gateKeeper: opts.gateKeeper,
                 gateKeeperId: opts.gateKeeperId,
-                governanceOpts: opts.governanceOpts
+                governanceOpts: opts.governanceOpts,
+                ens: opts.ens
             })
         );
 

--- a/contracts/crowdfund/BuyCrowdfund.sol
+++ b/contracts/crowdfund/BuyCrowdfund.sol
@@ -55,6 +55,8 @@ contract BuyCrowdfund is BuyCrowdfundBase {
         // Fixed governance options (i.e. cannot be changed) that the governance
         // `Party` will be created with if the crowdfund succeeds.
         FixedGovernanceOpts governanceOpts;
+        // Optional ENS domain name options to use for the crowdfund and party.
+        ENS ens;
     }
 
     /// @notice The NFT token ID to buy.
@@ -88,7 +90,8 @@ contract BuyCrowdfund is BuyCrowdfundBase {
                 initialDelegate: opts.initialDelegate,
                 gateKeeper: opts.gateKeeper,
                 gateKeeperId: opts.gateKeeperId,
-                governanceOpts: opts.governanceOpts
+                governanceOpts: opts.governanceOpts,
+                ens: opts.ens
             })
         );
         onlyHostCanBuy = opts.onlyHostCanBuy;

--- a/contracts/crowdfund/BuyCrowdfundBase.sol
+++ b/contracts/crowdfund/BuyCrowdfundBase.sol
@@ -48,6 +48,8 @@ abstract contract BuyCrowdfundBase is Crowdfund {
         bytes12 gateKeeperId;
         // Governance options.
         FixedGovernanceOpts governanceOpts;
+        // Optional ENS domain name options to use for the crowdfund and party.
+        ENS ens;
     }
 
     event Won(Party party, IERC721 token, uint256 tokenId, uint256 settledPrice);
@@ -83,7 +85,8 @@ abstract contract BuyCrowdfundBase is Crowdfund {
                 initialDelegate: opts.initialDelegate,
                 gateKeeper: opts.gateKeeper,
                 gateKeeperId: opts.gateKeeperId,
-                governanceOpts: opts.governanceOpts
+                governanceOpts: opts.governanceOpts,
+                ens: opts.ens
             })
         );
     }

--- a/contracts/crowdfund/CollectionBuyCrowdfund.sol
+++ b/contracts/crowdfund/CollectionBuyCrowdfund.sol
@@ -52,6 +52,8 @@ contract CollectionBuyCrowdfund is BuyCrowdfundBase {
         // Fixed governance options (i.e. cannot be changed) that the governance
         // `Party` will be created with if the crowdfund succeeds.
         FixedGovernanceOpts governanceOpts;
+        // Optional ENS domain name options to use for the crowdfund and party.
+        ENS ens;
     }
 
     /// @notice The NFT contract to buy.
@@ -83,7 +85,8 @@ contract CollectionBuyCrowdfund is BuyCrowdfundBase {
                 initialDelegate: opts.initialDelegate,
                 gateKeeper: opts.gateKeeper,
                 gateKeeperId: opts.gateKeeperId,
-                governanceOpts: opts.governanceOpts
+                governanceOpts: opts.governanceOpts,
+                ens: opts.ens
             })
         );
         nftContract = opts.nftContract;

--- a/contracts/crowdfund/Crowdfund.sol
+++ b/contracts/crowdfund/Crowdfund.sol
@@ -147,10 +147,10 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
     ///         that should be minted to them if it could not be transferred to
     ///         them with `burn()`.
     mapping(address => Claim) public claims;
-    /// @notice Whether the DAO has emergency powers for this party.
-    bool public emergencyExecuteDisabled;
     // ENS domain options to pass on, if used, when creating the party after crowdfund wins.
     ENS private _ens;
+    /// @notice Whether the DAO has emergency powers for this party.
+    bool public emergencyExecuteDisabled;
 
     // Set the `Globals` contract.
     constructor(IGlobals globals) CrowdfundNFT(globals) {

--- a/contracts/crowdfund/CrowdfundFactory.sol
+++ b/contracts/crowdfund/CrowdfundFactory.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 import "../globals/IGlobals.sol";
 import "../utils/LibRawResult.sol";
 import "../utils/Proxy.sol";
+import "../utils/LibENS.sol";
 import "../renderers/RendererStorage.sol";
 
 import "./AuctionCrowdfund.sol";
@@ -37,6 +38,14 @@ contract CrowdfundFactory {
     ///         known token ID) listing for a known price.
     /// @param opts Options used to initialize the crowdfund. These are fixed
     ///             and cannot be changed later.
+    ///
+    ///             IMPORTANT: If using a custom ENS domain (aka. not a
+    ///             "partybid.eth" subdomain) for the crowdfund, the owner MUST
+    ///             authorize the crowdfund to be able to edit the domain's
+    ///             records so that it can update the address record to the new
+    ///             party after it wins. This can be done by calling
+    ///             `setAuthorisation()` on the ENS public resolver at:
+    ///             0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41.
     /// @param createGateCallData Encoded calldata used by `createGate()` to
     ///                           create the crowdfund if one is specified in `opts`.
     function createBuyCrowdfund(
@@ -44,6 +53,13 @@ contract CrowdfundFactory {
         bytes memory createGateCallData
     ) public payable returns (BuyCrowdfund inst) {
         opts.gateKeeperId = _prepareGate(opts.gateKeeper, opts.gateKeeperId, createGateCallData);
+
+        // Create a "partybid.eth" subdomain for the crowdfund if specified.
+        bytes32 subdomainNode;
+        if (LibENS.isPartyBidSubdomain(opts.ens.node)) {
+            subdomainNode = LibENS.createSubdomain(opts.ens.label, address(this));
+        }
+
         inst = BuyCrowdfund(
             payable(
                 new Proxy{ value: msg.value }(
@@ -52,6 +68,13 @@ contract CrowdfundFactory {
                 )
             )
         );
+
+        // Finish configuring subdomain if newly created.
+        if (subdomainNode != bytes32(0)) {
+            LibENS.setAddress(subdomainNode, address(inst));
+            LibENS.setAuthorization(subdomainNode, address(inst), true);
+        }
+
         emit BuyCrowdfundCreated(inst, opts);
     }
 
@@ -59,6 +82,14 @@ contract CrowdfundFactory {
     ///         (i.e. with a known token ID).
     /// @param opts Options used to initialize the crowdfund. These are fixed
     ///             and cannot be changed later.
+    ///
+    ///             IMPORTANT: If using a custom ENS domain (aka. not a
+    ///             "partybid.eth" subdomain) for the crowdfund, the owner MUST
+    ///             authorize the crowdfund to be able to edit the domain's
+    ///             records so that it can update the address record to the new
+    ///             party after it wins. This can be done by calling
+    ///             `setAuthorisation()` on the ENS public resolver at:
+    ///             0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41.
     /// @param createGateCallData Encoded calldata used by `createGate()` to create
     ///                           the crowdfund if one is specified in `opts`.
     function createAuctionCrowdfund(
@@ -66,6 +97,13 @@ contract CrowdfundFactory {
         bytes memory createGateCallData
     ) public payable returns (AuctionCrowdfund inst) {
         opts.gateKeeperId = _prepareGate(opts.gateKeeper, opts.gateKeeperId, createGateCallData);
+
+        // Create a "partybid.eth" subdomain for the crowdfund if specified.
+        bytes32 subdomainNode;
+        if (LibENS.isPartyBidSubdomain(opts.ens.node)) {
+            subdomainNode = LibENS.createSubdomain(opts.ens.label, address(this));
+        }
+
         inst = AuctionCrowdfund(
             payable(
                 new Proxy{ value: msg.value }(
@@ -74,6 +112,13 @@ contract CrowdfundFactory {
                 )
             )
         );
+
+        // Finish configuring subdomain if newly created.
+        if (subdomainNode != bytes32(0)) {
+            LibENS.setAddress(subdomainNode, address(inst));
+            LibENS.setAuthorization(subdomainNode, address(inst), true);
+        }
+
         emit AuctionCrowdfundCreated(inst, opts);
     }
 
@@ -81,6 +126,14 @@ contract CrowdfundFactory {
     ///         (i.e. any token ID) from a collection for a known price.
     /// @param opts Options used to initialize the crowdfund. These are fixed
     ///             and cannot be changed later.
+    ///
+    ///             IMPORTANT: If using a custom ENS domain (aka. not a
+    ///             "partybid.eth" subdomain) for the crowdfund, the owner MUST
+    ///             authorize the crowdfund to be able to edit the domain's
+    ///             records so that it can update the address record to the new
+    ///             party after it wins. This can be done by calling
+    ///             `setAuthorisation()` on the ENS public resolver at:
+    ///             0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41.
     /// @param createGateCallData Encoded calldata used by `createGate()` to create
     ///                           the crowdfund if one is specified in `opts`.
     function createCollectionBuyCrowdfund(
@@ -88,6 +141,13 @@ contract CrowdfundFactory {
         bytes memory createGateCallData
     ) public payable returns (CollectionBuyCrowdfund inst) {
         opts.gateKeeperId = _prepareGate(opts.gateKeeper, opts.gateKeeperId, createGateCallData);
+
+        // Create a "partybid.eth" subdomain for the crowdfund if specified.
+        bytes32 subdomainNode;
+        if (LibENS.isPartyBidSubdomain(opts.ens.node)) {
+            subdomainNode = LibENS.createSubdomain(opts.ens.label, address(this));
+        }
+
         inst = CollectionBuyCrowdfund(
             payable(
                 new Proxy{ value: msg.value }(
@@ -96,6 +156,13 @@ contract CrowdfundFactory {
                 )
             )
         );
+
+        // Finish configuring subdomain if newly created.
+        if (subdomainNode != bytes32(0)) {
+            LibENS.setAddress(subdomainNode, address(inst));
+            LibENS.setAuthorization(subdomainNode, address(inst), true);
+        }
+
         emit CollectionBuyCrowdfundCreated(inst, opts);
     }
 

--- a/contracts/party/IPartyFactory.sol
+++ b/contracts/party/IPartyFactory.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.17;
 
 import "../globals/IGlobals.sol";
 import "../tokens/IERC721.sol";
+import "../utils/LibENS.sol";
 
 import "./Party.sol";
 
@@ -32,7 +33,8 @@ interface IPartyFactory {
         address authority,
         Party.PartyOptions calldata opts,
         IERC721[] memory preciousTokens,
-        uint256[] memory preciousTokenIds
+        uint256[] memory preciousTokenIds,
+        ENS memory ens
     ) external returns (Party party);
 
     /// @notice The `Globals` contract storing global configuration values. This contract

--- a/contracts/party/Party.sol
+++ b/contracts/party/Party.sol
@@ -23,6 +23,7 @@ contract Party is PartyGovernanceNFT {
         IERC721[] preciousTokens;
         uint256[] preciousTokenIds;
         address mintAuthority;
+        string ensName;
     }
 
     // Set the `Globals` contract.
@@ -39,7 +40,8 @@ contract Party is PartyGovernanceNFT {
             initData.options.governance,
             initData.preciousTokens,
             initData.preciousTokenIds,
-            initData.mintAuthority
+            initData.mintAuthority,
+            initData.ensName
         );
     }
 

--- a/contracts/party/PartyGovernance.sol
+++ b/contracts/party/PartyGovernance.sol
@@ -12,6 +12,7 @@ import "../tokens/ERC1155Receiver.sol";
 import "../utils/LibERC20Compat.sol";
 import "../utils/LibRawResult.sol";
 import "../utils/LibSafeCast.sol";
+import "../utils/LibENS.sol";
 import "../globals/IGlobals.sol";
 import "../globals/LibGlobals.sol";
 import "../proposals/IProposalExecutionEngine.sol";
@@ -287,7 +288,8 @@ abstract contract PartyGovernance is
     function _initialize(
         GovernanceOpts memory opts,
         IERC721[] memory preciousTokens,
-        uint256[] memory preciousTokenIds
+        uint256[] memory preciousTokenIds,
+        string memory ensName
     ) internal virtual {
         // Check BPS are valid.
         if (opts.feeBps > 1e4) {
@@ -311,6 +313,10 @@ abstract contract PartyGovernance is
         // Set fees.
         feeBps = opts.feeBps;
         feeRecipient = opts.feeRecipient;
+        // Set the ENS name for the party.
+        if (bytes(ensName).length != 0) {
+            LibENS.setDomainName(ensName);
+        }
         // Set the precious list.
         _setPreciousList(preciousTokens, preciousTokenIds);
         // Set the party hosts.

--- a/contracts/party/PartyGovernanceNFT.sol
+++ b/contracts/party/PartyGovernanceNFT.sol
@@ -54,9 +54,10 @@ contract PartyGovernanceNFT is PartyGovernance, ERC721, IERC2981 {
         PartyGovernance.GovernanceOpts memory governanceOpts,
         IERC721[] memory preciousTokens,
         uint256[] memory preciousTokenIds,
-        address mintAuthority_
+        address mintAuthority_,
+        string memory ensName
     ) internal {
-        PartyGovernance._initialize(governanceOpts, preciousTokens, preciousTokenIds);
+        PartyGovernance._initialize(governanceOpts, preciousTokens, preciousTokenIds, ensName);
         name = name_;
         symbol = symbol_;
         mintAuthority = mintAuthority_;

--- a/contracts/utils/LibENS.sol
+++ b/contracts/utils/LibENS.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.17;
+
+import "./vendor/ENS.sol";
+
+struct ENS {
+    // Domain name (eg. "partybid.eth")
+    string name;
+    // Node of the domain, hashed as specified in EIP-137
+    bytes32 node;
+    // Hash of the label specifying the subnode
+    bytes32 label;
+}
+
+ENSRegistry constant ENS_REGISTRY = ENSRegistry(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
+ENSReverseRegistry constant REVERSE_REGISTRY = ENSReverseRegistry(
+    0x084b1c3C81545d370f3634392De611CaaBFf8148
+);
+ENSResolver constant RESOLVER = ENSResolver(0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41);
+
+// Namehash of "partybid.eth".
+bytes32 constant DOMAIN_NODE = 0x739b60d02a3e52e8503ff5878da2ef95a296699ebfb38590f1affcdd513f2796;
+// Owner of the "partybid.eth" domain.
+address constant DOMAIN_OWNER = 0xF7f52Dd34bc21eDA08c0b804C7c1dbc48375820f;
+
+/// @notice Base class for contracts to create and register an ENS subdomains for partybid.eth.
+library LibENS {
+    error DomainAlreadyRegistered(bytes32 node, address owner);
+    error UnauthorizedForDomain(bytes32 node, address unauthorized);
+
+    function createSubdomain(bytes32 label, address owner) internal returns (bytes32 subnode) {
+        subnode = keccak256(abi.encodePacked(DOMAIN_NODE, label));
+
+        // Ensure subdomain doesn't already exist.
+        address prevOwner = ENS_REGISTRY.owner(subnode);
+        if (prevOwner != address(0)) revert DomainAlreadyRegistered(subnode, prevOwner);
+
+        ENS_REGISTRY.setSubnodeRecord(DOMAIN_NODE, label, owner, address(RESOLVER), 0);
+    }
+
+    function setSubdomainOwnership(bytes32 node, bytes32 label, address newOwner) internal {
+        ENS_REGISTRY.setSubnodeOwner(node, label, newOwner);
+    }
+
+    function setDomainName(string memory name) internal {
+        REVERSE_REGISTRY.setName(name);
+    }
+
+    function setAddress(bytes32 node, address addr) internal {
+        // Set the resolver record of a subdomain.
+        RESOLVER.setAddr(node, addr);
+    }
+
+    function setAuthorization(bytes32 node, address operator, bool isAuthorized) internal {
+        RESOLVER.setAuthorisation(node, operator, isAuthorized);
+    }
+
+    function ensureIsAuthorized(bytes32 node, address operator) internal view {
+        if (!RESOLVER.authorisations(node, ENS_REGISTRY.owner(node), operator))
+            revert UnauthorizedForDomain(node, operator);
+    }
+
+    function isPartyBidSubdomain(bytes32 node) internal pure returns (bool) {
+        return node == DOMAIN_NODE;
+    }
+}

--- a/contracts/utils/LibENS.sol
+++ b/contracts/utils/LibENS.sol
@@ -4,11 +4,11 @@ pragma solidity 0.8.17;
 import "./vendor/ENS.sol";
 
 struct ENS {
-    // Domain name (eg. "partybid.eth")
+    // Domain name (eg. "livingdead.partybid.eth")
     string name;
-    // Node of the domain, hashed as specified in EIP-137
+    // Node of the domain (eg. "partybid.eth"), hashed as specified in EIP-137
     bytes32 node;
-    // Hash of the label specifying the subnode
+    // Hash of the domain label (eg. `keccak256("livingdead")`)
     bytes32 label;
 }
 

--- a/contracts/utils/vendor/ENS.sol
+++ b/contracts/utils/vendor/ENS.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface ENSRegistry {
+    function setRecord(
+        bytes32 node,
+        address owner,
+        address resolver,
+        uint64 ttl
+    ) external;
+
+    function setSubnodeRecord(
+        bytes32 node,
+        bytes32 label,
+        address owner,
+        address resolver,
+        uint64 ttl
+    ) external;
+
+    function setSubnodeOwner(
+        bytes32 node,
+        bytes32 label,
+        address owner
+    ) external returns (bytes32);
+
+    function setResolver(bytes32 node, address resolver) external;
+
+    function setOwner(bytes32 node, address owner) external;
+
+    function setTTL(bytes32 node, uint64 ttl) external;
+
+    function setApprovalForAll(address operator, bool approved) external;
+
+    function owner(bytes32 node) external view returns (address);
+
+    function resolver(bytes32 node) external view returns (address);
+
+    function ttl(bytes32 node) external view returns (uint64);
+
+    function recordExists(bytes32 node) external view returns (bool);
+
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+}
+
+interface ENSResolver {
+    /**
+     * Sets the address associated with an ENS node.
+     * May only be called by the owner of that node in the ENS registry.
+     * @param node The node to update.
+     * @param a The address to set.
+     */
+    function setAddr(bytes32 node, address a) external;
+
+    /**
+     * Returns the address associated with an ENS node.
+     * @param node The ENS node to query.
+     * @return The associated address.
+     */
+    function addr(bytes32 node) external view returns (address);
+
+    /**
+     * Returns the name associated with an ENS node, for reverse records.
+     * Defined in EIP181.
+     * @param node The ENS node to query.
+     * @return The associated name.
+     */
+    function name(bytes32 node) external view returns (string memory);
+
+    /**
+     * @dev Sets or clears an authorisation.
+     * Authorisations are specific to the caller. Any account can set an authorisation
+     * for any name, but the authorisation that is checked will be that of the
+     * current owner of a name. Thus, transferring a name effectively clears any
+     * existing authorisations, and new authorisations can be set in advance of
+     * an ownership transfer if desired.
+     *
+     * @param node The name to change the authorisation on.
+     * @param target The address that is to be authorised or deauthorised.
+     * @param isAuthorised True if the address should be authorised, or false if it should be deauthorised.
+     */
+    function setAuthorisation(
+        bytes32 node,
+        address target,
+        bool isAuthorised
+    ) external;
+
+    /**
+     * A mapping of authorisations. An address that is authorised for a name
+     * may make any changes to the name that the owner could, but may not update
+     * the set of authorisations.
+     * (node, owner, caller) => isAuthorised
+     */
+    function authorisations(
+        bytes32 node,
+        address owner,
+        address operator
+    ) external view returns (bool);
+}
+
+interface ENSReverseRegistry {
+    /**
+     * @dev Sets the `name()` record for the reverse ENS record associated with
+     * the calling account. First updates the resolver to the default reverse
+     * resolver if necessary.
+     * @param name The name to set for this address.
+     * @return The ENS node hash of the reverse record.
+     */
+    function setName(string memory name) external returns (bytes32);
+
+    /**
+     * @dev Returns the node hash for a given account's reverse records.
+     * @param addr The address to hash
+     * @return The ENS node hash.
+     */
+    function node(address addr) external pure returns (bytes32);
+}

--- a/sol-tests/TestUsers.sol
+++ b/sol-tests/TestUsers.sol
@@ -102,11 +102,14 @@ contract PartyAdmin is Test {
         uint256[] memory preciousTokenIds = new uint256[](1);
         preciousTokenIds[0] = opts.preciousTokenId;
 
+        ENS memory defaultENS;
+
         Party party = _partyFactory.createParty(
             address(this),
             po,
             preciousTokens,
-            preciousTokenIds
+            preciousTokenIds,
+            defaultENS
         );
         return (party, preciousTokens, preciousTokenIds);
     }

--- a/sol-tests/crowdfund/AuctionCrowdfund.t.sol
+++ b/sol-tests/crowdfund/AuctionCrowdfund.t.sol
@@ -51,6 +51,7 @@ contract AuctionCrowdfundTest is Test, TestUtils {
     IGateKeeper defaultGateKeeper;
     bytes12 defaultGateKeeperId;
     Crowdfund.FixedGovernanceOpts defaultGovernanceOpts;
+    ENS defaultENS;
 
     Globals globals = new Globals(address(this));
     MockPartyFactory partyFactory = new MockPartyFactory();
@@ -100,7 +101,8 @@ contract AuctionCrowdfundTest is Test, TestUtils {
                                 gateKeeper: gateKeeper,
                                 gateKeeperId: gateKeeperId,
                                 onlyHostCanBid: onlyHostCanBid,
-                                governanceOpts: defaultGovernanceOpts
+                                governanceOpts: defaultGovernanceOpts,
+                                ens: defaultENS
                             })
                         )
                     )
@@ -445,7 +447,7 @@ contract AuctionCrowdfundTest is Test, TestUtils {
         // Contribute and delegate.
         address payable contributor = _randomAddress();
         _contribute(cf, contributor, 1e18);
-        uint256 bid = market.getMinimumBid(auctionId);
+        market.getMinimumBid(auctionId);
         // Expire the CF.
         skip(defaultDuration);
         _expectEmit0();
@@ -732,7 +734,8 @@ contract AuctionCrowdfundTest is Test, TestUtils {
                                 gateKeeper: defaultGateKeeper,
                                 gateKeeperId: defaultGateKeeperId,
                                 onlyHostCanBid: false,
-                                governanceOpts: defaultGovernanceOpts
+                                governanceOpts: defaultGovernanceOpts,
+                                ens: defaultENS
                             })
                         )
                     )

--- a/sol-tests/crowdfund/BuyCrowdfund.t.sol
+++ b/sol-tests/crowdfund/BuyCrowdfund.t.sol
@@ -44,6 +44,7 @@ contract BuyCrowdfundTest is Test, TestUtils {
     IGateKeeper defaultGateKeeper;
     bytes12 defaultGateKeeperId;
     Crowdfund.FixedGovernanceOpts defaultGovernanceOpts;
+    ENS defaultENS;
 
     Globals globals = new Globals(address(this));
     MockPartyFactory partyFactory = new MockPartyFactory();
@@ -90,7 +91,8 @@ contract BuyCrowdfundTest is Test, TestUtils {
                                 gateKeeper: gateKeeper,
                                 gateKeeperId: gateKeeperId,
                                 onlyHostCanBuy: onlyHostCanBuy,
-                                governanceOpts: defaultGovernanceOpts
+                                governanceOpts: defaultGovernanceOpts,
+                                ens: defaultENS
                             })
                         )
                     )
@@ -515,7 +517,8 @@ contract BuyCrowdfundTest is Test, TestUtils {
                                 gateKeeper: defaultGateKeeper,
                                 gateKeeperId: defaultGateKeeperId,
                                 onlyHostCanBuy: false,
-                                governanceOpts: defaultGovernanceOpts
+                                governanceOpts: defaultGovernanceOpts,
+                                ens: defaultENS
                             })
                         )
                     )

--- a/sol-tests/crowdfund/CollectionBuyCrowdfund.t.sol
+++ b/sol-tests/crowdfund/CollectionBuyCrowdfund.t.sol
@@ -43,6 +43,7 @@ contract CollectionBuyCrowdfundTest is Test, TestUtils {
     IGateKeeper defaultGateKeeper;
     bytes12 defaultGateKeeperId;
     Crowdfund.FixedGovernanceOpts defaultGovernanceOpts;
+    ENS defaultENS;
 
     Globals globals = new Globals(address(this));
     MockPartyFactory partyFactory = new MockPartyFactory();
@@ -85,7 +86,8 @@ contract CollectionBuyCrowdfundTest is Test, TestUtils {
                                 initialDelegate: defaultInitialDelegate,
                                 gateKeeper: defaultGateKeeper,
                                 gateKeeperId: defaultGateKeeperId,
-                                governanceOpts: governanceOpts
+                                governanceOpts: governanceOpts,
+                                ens: defaultENS
                             })
                         )
                     )
@@ -253,7 +255,8 @@ contract CollectionBuyCrowdfundTest is Test, TestUtils {
                                 initialDelegate: initialDelegate,
                                 gateKeeper: defaultGateKeeper,
                                 gateKeeperId: defaultGateKeeperId,
-                                governanceOpts: defaultGovernanceOpts
+                                governanceOpts: defaultGovernanceOpts,
+                                ens: defaultENS
                             })
                         )
                     )

--- a/sol-tests/crowdfund/Crowdfund.t.sol
+++ b/sol-tests/crowdfund/Crowdfund.t.sol
@@ -62,6 +62,7 @@ contract CrowdfundTest is Test, TestUtils {
     IGateKeeper defaultGateKeeper;
     bytes12 defaultGateKeeperId;
     Crowdfund.FixedGovernanceOpts defaultGovernanceOpts;
+    ENS defaultENS;
     address dao;
     EmergencyExecuteTarget emergencyExecuteTarget = new EmergencyExecuteTarget();
 
@@ -143,7 +144,8 @@ contract CrowdfundTest is Test, TestUtils {
                                 initialDelegate: initialDelegate,
                                 gateKeeper: defaultGateKeeper,
                                 gateKeeperId: defaultGateKeeperId,
-                                governanceOpts: defaultGovernanceOpts
+                                governanceOpts: defaultGovernanceOpts,
+                                ens: defaultENS
                             })
                         )
                     )
@@ -927,7 +929,8 @@ contract CrowdfundTest is Test, TestUtils {
                                 initialDelegate: address(this),
                                 gateKeeper: defaultGateKeeper,
                                 gateKeeperId: defaultGateKeeperId,
-                                governanceOpts: defaultGovernanceOpts
+                                governanceOpts: defaultGovernanceOpts,
+                                ens: defaultENS
                             })
                         )
                     )

--- a/sol-tests/crowdfund/FoundationForked.t.sol
+++ b/sol-tests/crowdfund/FoundationForked.t.sol
@@ -28,6 +28,7 @@ contract FoundationForkedTest is TestUtils {
     AuctionCrowdfund cf;
 
     Crowdfund.FixedGovernanceOpts defaultGovOpts;
+    ENS defaultENS;
 
     // Initialize Foundation contracts
     IFoundationMarket foundation = IFoundationMarket(0xcDA72070E455bb31C7690a170224Ce43623d0B6f);
@@ -74,7 +75,8 @@ contract FoundationForkedTest is TestUtils {
                                 gateKeeper: IGateKeeper(address(0)),
                                 gateKeeperId: 0,
                                 onlyHostCanBid: false,
-                                governanceOpts: defaultGovOpts
+                                governanceOpts: defaultGovOpts,
+                                ens: defaultENS
                             })
                         )
                     )

--- a/sol-tests/crowdfund/MockPartyFactory.sol
+++ b/sol-tests/crowdfund/MockPartyFactory.sol
@@ -23,7 +23,8 @@ contract MockPartyFactory is IPartyFactory {
         address authority,
         Party.PartyOptions memory opts,
         IERC721[] memory preciousTokens,
-        uint256[] memory preciousTokenIds
+        uint256[] memory preciousTokenIds,
+        ENS memory
     ) external returns (Party party) {
         emit MockPartyFactoryCreateParty(
             msg.sender,

--- a/sol-tests/crowdfund/NounsForked.t.sol
+++ b/sol-tests/crowdfund/NounsForked.t.sol
@@ -27,6 +27,7 @@ contract NounsForkedTest is TestUtils {
     AuctionCrowdfund cf;
 
     Crowdfund.FixedGovernanceOpts defaultGovOpts;
+    ENS defaultENS;
 
     // Initialize nouns contracts
     INounsAuctionHouse nounsAuctionHouse =
@@ -67,7 +68,8 @@ contract NounsForkedTest is TestUtils {
                                 gateKeeper: IGateKeeper(address(0)),
                                 gateKeeperId: 0,
                                 onlyHostCanBid: false,
-                                governanceOpts: defaultGovOpts
+                                governanceOpts: defaultGovOpts,
+                                ens: defaultENS
                             })
                         )
                     )

--- a/sol-tests/crowdfund/ZoraForked.t.sol
+++ b/sol-tests/crowdfund/ZoraForked.t.sol
@@ -28,6 +28,7 @@ contract ZoraForkedTest is TestUtils, ERC721Receiver {
     AuctionCrowdfund cf;
 
     Crowdfund.FixedGovernanceOpts defaultGovOpts;
+    ENS defaultENS;
 
     // Initialize Zora contracts
     IZoraAuctionHouse zora = IZoraAuctionHouse(0xE468cE99444174Bd3bBBEd09209577d25D1ad673);
@@ -77,7 +78,8 @@ contract ZoraForkedTest is TestUtils, ERC721Receiver {
                                 gateKeeper: IGateKeeper(address(0)),
                                 gateKeeperId: 0,
                                 onlyHostCanBid: false,
-                                governanceOpts: defaultGovOpts
+                                governanceOpts: defaultGovOpts,
+                                ens: defaultENS
                             })
                         )
                     )

--- a/sol-tests/party/PartyGovernanceNFTUnit.sol
+++ b/sol-tests/party/PartyGovernanceNFTUnit.sol
@@ -29,7 +29,8 @@ contract TestablePartyGovernanceNFT is PartyGovernanceNFT {
             governanceOpts,
             preciousTokens,
             preciousTokenIds,
-            mintAuthority_
+            mintAuthority_,
+            ""
         );
     }
 

--- a/sol-tests/party/PartyGovernanceUnit.t.sol
+++ b/sol-tests/party/PartyGovernanceUnit.t.sol
@@ -151,7 +151,7 @@ contract TestablePartyGovernance is PartyGovernance {
         IERC721[] memory preciousTokens,
         uint256[] memory preciousTokenIds
     ) PartyGovernance(globals) {
-        _initialize(opts, preciousTokens, preciousTokenIds);
+        _initialize(opts, preciousTokens, preciousTokenIds, "");
     }
 
     function rawAdjustVotingPower(

--- a/sol-tests/utils/CrowdfundHelpers.t.sol
+++ b/sol-tests/utils/CrowdfundHelpers.t.sol
@@ -28,6 +28,7 @@ contract CrowdfundHelpers is Test, TestUtils {
     IGateKeeper defaultGateKeeper;
     bytes12 defaultGateKeeperId;
     Crowdfund.FixedGovernanceOpts defaultGovernanceOpts;
+    ENS defaultENS;
 
     Globals globals;
     AuctionCrowdfund auctionCrowdfundImpl;
@@ -85,7 +86,8 @@ contract CrowdfundHelpers is Test, TestUtils {
                                 gateKeeper: defaultGateKeeper,
                                 gateKeeperId: defaultGateKeeperId,
                                 onlyHostCanBid: false,
-                                governanceOpts: defaultGovernanceOpts
+                                governanceOpts: defaultGovernanceOpts,
+                                ens: defaultENS
                             })
                         )
                     )
@@ -119,7 +121,8 @@ contract CrowdfundHelpers is Test, TestUtils {
                                 gateKeeper: defaultGateKeeper,
                                 gateKeeperId: defaultGateKeeperId,
                                 onlyHostCanBuy: false,
-                                governanceOpts: defaultGovernanceOpts
+                                governanceOpts: defaultGovernanceOpts,
+                                ens: defaultENS
                             })
                         )
                     )
@@ -152,7 +155,8 @@ contract CrowdfundHelpers is Test, TestUtils {
                                 initialDelegate: defaultInitialDelegate,
                                 gateKeeper: defaultGateKeeper,
                                 gateKeeperId: defaultGateKeeperId,
-                                governanceOpts: defaultGovernanceOpts
+                                governanceOpts: defaultGovernanceOpts,
+                                ens: defaultENS
                             })
                         )
                     )

--- a/tests/deploy/mainnet.t.deploy.ts
+++ b/tests/deploy/mainnet.t.deploy.ts
@@ -119,6 +119,12 @@ describeFork("Mainnet deployment fork smoke tests", provider => {
     feeRecipient: deployOwner.address,
   };
 
+  const ENS = {
+    name: "",
+    node: NULL_HASH,
+    label: NULL_HASH,
+  };
+
   let dummyERC721Contract: Contract;
   let testERC721tokenIds: BigNumber[] = [];
   let deployer: Contract;
@@ -249,6 +255,7 @@ describeFork("Mainnet deployment fork smoke tests", provider => {
               gateKeeperId: NULL_GATEKEEPER_ID,
               onlyHostCanBid: true,
               governanceOpts: FIXED_GOVERNANCE_OPTS,
+              ens: ENS,
             },
             NULL_BYTES,
           ),
@@ -320,6 +327,7 @@ describeFork("Mainnet deployment fork smoke tests", provider => {
             gateKeeper: NULL_ADDRESS,
             gateKeeperId: NULL_GATEKEEPER_ID,
             governanceOpts: FIXED_GOVERNANCE_OPTS,
+            ens: ENS,
           },
           NULL_BYTES,
         ),
@@ -390,6 +398,7 @@ describeFork("Mainnet deployment fork smoke tests", provider => {
             gateKeeper: NULL_ADDRESS,
             gateKeeperId: NULL_GATEKEEPER_ID,
             governanceOpts: FIXED_GOVERNANCE_OPTS,
+            ens: ENS,
           },
           NULL_BYTES,
         ),

--- a/tests/integration/system.ts
+++ b/tests/integration/system.ts
@@ -300,6 +300,11 @@ export class Party {
         },
         preciousTokens.map(({ token }) => token.address),
         preciousTokens.map(({ tokenId }) => tokenId),
+        {
+          name: "",
+          node: NULL_HASH,
+          label: NULL_HASH,
+        },
       )
     ).wait();
     const partyAddress = tx.events.find((e: any) => e.event === "PartyCreated").args[0];


### PR DESCRIPTION
A new parameter `ENS ens` is now available when creating crowdfunds and parties. This parameter is a struct with the following fields:
```solidity
struct ENS {
    // Domain name (eg. "livingdead.partybid.eth")
    string name;
    // Node of the domain (eg. "partybid.eth"), hashed as specified in EIP-137
    bytes32 node;
    // Hash of the domain label (eg. `keccak256("livingdead")`)
    bytes32 label;
}
```
The `node` and `label` for a "partybid.eth" subdomain is
```solidity
// Namehash of "partybid.eth".
bytes32 node = 0x739b60d02a3e52e8503ff5878da2ef95a296699ebfb38590f1affcdd513f2796;
bytes32 label = keccak256(subdomain);
```
where `subdomain` is, for example, "livingdead" if the the full domain was "livingdead.partybid.eth".

See [here](https://docs.ens.domains/contract-api-reference/name-processing#hashing-names) for how to get the `node` and `label` for other custom domains. Note that the `label` field is what they call "label hash" in the guide. 

## Requirements to support this feature

### Security

- [ ] Have 0xMacro or Lawrence take a look

### Admin

- [ ] PartyDAO multisig (`0xF7f52Dd34bc21eDA08c0b804C7c1dbc48375820f`) must own the "partybid.eth" domain
- [ ] PartyDAO multisig must call following function to set domain permissions for both `CrowdfundFactory` and `PartyFactory` to create subdomains and update records:
    - `ENSRegistry.approve()`
    - `PublicResolver.setAuthorisation()`

### Frontend

- [ ] [Normalize](https://docs.ens.domains/contract-api-reference/name-processing#normalising-names) the user-given domain name string before using it internally
- [ ] Support new `ens` parameter in crowdfund/party creation functions
- [ ] If the given domain name is custom (aka. not a "partybid.eth" subdomain), perform the additional validations to make sure using the custom domain does not brick the crowdfund/party:
    - Validate that the owner of the ENS domain is the user submitting the transaction
    - Validate that the domain's resolver is the [ENS public resolver](https://etherscan.io/address/0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41#code)
    - Validate that the ETH address record of the ENS domain points to the address of the crowdfund/party
        - If not, ask them to sign a transaction to `setAddr()` on the public resolver to update the ETH address record
    - If creating a crowdfund, validate that the owner of the domain has authorized the crowdfund in the public resolver.
        - If the crowdfund is not authorized, ask them to sign a transaction to `setAuthorisation()` for the crowdfund contract before creating it
        - See [here](https://github.com/PartyDAO/party-protocol/blob/8178f7039b32a15391f8c457f567c19ef949c3ea/contracts/crowdfund/CrowdfundFactory.sol#L42) for more details