### PR TITLE
refactor(`FractionalizeProposal`): remove useless `listPrice` param

### DIFF
--- a/contracts/proposals/FractionalizeProposal.sol
+++ b/contracts/proposals/FractionalizeProposal.sol
@@ -15,16 +15,13 @@ contract FractionalizeProposal {
         IERC721 token;
         // The ERC721 token ID to fractionalize.
         uint256 tokenId;
-        // The starting list price for the fractional vault.
-        uint256 listPrice;
     }
 
     event FractionalV1VaultCreated(
         IERC721 indexed token,
         uint256 indexed tokenId,
         uint256 vaultId,
-        IERC20 vault,
-        uint256 listPrice
+        IERC20 vault
     );
 
     /// @notice Deployment of https://github.com/fractional-company/contracts/blob/master/src/ERC721TokenVault.sol.
@@ -55,7 +52,11 @@ contract FractionalizeProposal {
             data.token,
             data.tokenId,
             supply,
-            data.listPrice,
+            // Since we are distributing the entire supply immediately after
+            // fractionalizing, in practice setting an initial reserve price
+            // does not do anything because it will get reset to 0 after the
+            // distribution is created.
+            0,
             0
         );
         // Get the vault we just created.
@@ -65,7 +66,7 @@ contract FractionalizeProposal {
         assert(vault.balanceOf(address(this)) == supply);
         // Remove ourselves as curator.
         vault.updateCurator(address(0));
-        emit FractionalV1VaultCreated(data.token, data.tokenId, vaultId, vault, data.listPrice);
+        emit FractionalV1VaultCreated(data.token, data.tokenId, vaultId, vault);
         // Create distribution for fractional tokens for party.
         PartyGovernance(address(this)).distribute(
             ITokenDistributor.TokenType.Erc20,

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -455,8 +455,6 @@ abi.encodeWithSelector(
         /* IERC721 */ token;
         // The ERC721 token ID to fractionalize.
         /* uint256 */ tokenId;
-        // The starting reserve price for the fractional vault.
-        /* uint256 */ listPrice;
     )
 );
 ```
@@ -466,7 +464,6 @@ abi.encodeWithSelector(
 This proposal is atomic, completing in 1 step (aka. 1 `execute()` call):
 
 1. Create a new Fractional V1 vault around `token` + `tokenId`.
-   - Reserve price will be set to the proposal's `listPrice`.
    - Curator will be set to `address(0)`.
    - `totalVotingPower` fractional ERC20 tokens will be minted and held by the Party, which can later be claimed through an ERC20 distribution.
 

--- a/sol-tests/proposals/FractionalizeProposalForked.t.sol
+++ b/sol-tests/proposals/FractionalizeProposalForked.t.sol
@@ -70,8 +70,7 @@ contract FractionalizeProposalForkedTest is TestUtils {
         IERC721 indexed token,
         uint256 indexed tokenId,
         uint256 vaultId,
-        IERC20 vault,
-        uint256 listPrice
+        IERC20 vault
     );
 
     IFractionalV1VaultFactory VAULT_FACTORY =
@@ -85,11 +84,10 @@ contract FractionalizeProposalForkedTest is TestUtils {
 
     function testForked_canFractionalize() external onlyForked {
         uint256 tokenId = erc721.mint(address(impl));
-        uint256 listPrice = 1337 ether;
         uint256 expectedVaultId = VAULT_FACTORY.vaultCount();
         IFractionalV1Vault expectedVault = _getNextVault();
         _expectEmit2();
-        emit FractionalV1VaultCreated(erc721, tokenId, expectedVaultId, expectedVault, listPrice);
+        emit FractionalV1VaultCreated(erc721, tokenId, expectedVaultId, expectedVault);
         _expectEmit0();
         emit MockCreateDistribution(
             address(impl),
@@ -108,8 +106,7 @@ contract FractionalizeProposalForkedTest is TestUtils {
                 proposalData: abi.encode(
                     FractionalizeProposal.FractionalizeProposalData({
                         token: erc721,
-                        tokenId: tokenId,
-                        listPrice: listPrice
+                        tokenId: tokenId
                     })
                 )
             })
@@ -119,7 +116,6 @@ contract FractionalizeProposalForkedTest is TestUtils {
             expectedVault.balanceOf(address(impl)),
             impl.getGovernanceValues().totalVotingPower
         );
-        assertEq(expectedVault.reservePrice(), listPrice);
         assertEq(expectedVault.curator(), address(0));
     }
 


### PR DESCRIPTION
Since the entire supply is distributed immediately after fractionalizing, in practice setting an initial reserve price does not do anything because it gets reset to 0 after the distribution is created.