### PR TITLE
refactor(renderer): do not use fixed storage layout

### DIFF
--- a/contracts/renderers/CrowdfundNFTRenderer.sol
+++ b/contracts/renderers/CrowdfundNFTRenderer.sol
@@ -29,25 +29,8 @@ contract CrowdfundNFTRenderer is RendererBase {
         IFont font
     ) RendererBase(globals, rendererStorage, font) {}
 
-    // The renderer is called via delegateCall, so we need to declare the storage layout.
-    // Run `yarn build && yarn layout Crowdfund.sol/Crowdfund` to generate the current layout.
-    string name;
-    string symbol;
-    mapping(uint256 => address) _owners;
-    Party party;
-    uint96 totalContributions;
-    IGateKeeper gateKeeper;
-    bytes12 gateKeeperId;
-    address payable splitRecipient;
-    uint16 splitBps;
-    bool _splitRecipientHasBurned;
-    bytes32 governanceOptsHash;
-    mapping(address => address) delegationsByContributor;
-    mapping(address => Crowdfund.Contribution[]) _contributionsByContributor;
-    mapping(address => Crowdfund.Claim) claims;
-
     function tokenURI(uint256 tokenId) external view returns (string memory) {
-        address owner = _owners[tokenId];
+        address owner = Crowdfund(address(this)).ownerOf(tokenId);
         if (owner == address(0)) {
             revert InvalidTokenIdError();
         }
@@ -64,12 +47,12 @@ contract CrowdfundNFTRenderer is RendererBase {
                         '{"name":"',
                         generateName(owner),
                         '", "description":"',
-                        generateDescription(name, owner),
+                        generateDescription(Crowdfund(address(this)).name(), owner),
                         '", "external_url":"',
                         generateExternalURL(),
                         '", "image":"',
                         generateSVG(
-                            name,
+                            Crowdfund(address(this)).name(),
                             getContribution(owner),
                             getCrowdfundStatus(),
                             color,
@@ -128,14 +111,14 @@ contract CrowdfundNFTRenderer is RendererBase {
     }
 
     function generateCollectionName() internal view override returns (string memory) {
-        return string.concat("Party Contributions: ", name);
+        return string.concat("Party Contributions: ", Crowdfund(address(this)).name());
     }
 
     function generateCollectionDescription() internal view override returns (string memory) {
         return
             string.concat(
                 "Party Cards in this collection represent contributions to the ",
-                name,
+                Crowdfund(address(this)).name(),
                 " crowdfund. When the crowdfund concludes, Party Cards can be used to claim ETH or activate membership in the Party. During the crowdfund, Party Cards are non-transferable. Head to ",
                 generateExternalURL(),
                 " to learn more about this Party."

--- a/sol-tests/party/PartyGovernanceNFT.t.sol
+++ b/sol-tests/party/PartyGovernanceNFT.t.sol
@@ -418,7 +418,7 @@ contract DummyParty is ReadOnlyDelegateCall {
     mapping(address => PartyGovernance.VotingPowerSnapshot[]) private _votingPowerSnapshotsByVoter;
     string public name;
     string public symbol;
-    mapping(uint256 => address) internal _ownerOf;
+    mapping(uint256 => address) public ownerOf;
     mapping(address => uint256) internal _balanceOf;
     mapping(uint256 => address) public getApproved;
     mapping(address => mapping(address => bool)) public isApprovedForAll;
@@ -450,7 +450,7 @@ contract DummyParty is ReadOnlyDelegateCall {
 
     function mint(uint256 tokenId) external {
         _balanceOf[msg.sender]++;
-        _ownerOf[tokenId] = msg.sender;
+        ownerOf[tokenId] = msg.sender;
     }
 
     function createMockProposal(PartyGovernance.ProposalStatus status) external {


### PR DESCRIPTION
The renderers "mirror" the layout of the Crowdfund contract (see [here](https://github.com/PartyDAO/party-protocol/blob/0c8b3b2f99216b12695e211d412584537dd63fa1/contracts/renderers/CrowdfundNFTRenderer.sol#L32)). In retrospect, this is a significant footgun because if the storage layout of the Crowdfund contract is changed the mirrored storage of the renderer contract will fall out of sync with that of the Crowdfund contract and lead to errors when rendering the NFT metadata with `tokenURI()`.