### PR TITLE
Feat/rage quit

### DIFF
--- a/contracts/crowdfund/Crowdfund.sol
+++ b/contracts/crowdfund/Crowdfund.sol
@@ -514,7 +514,7 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
             uint256 numContributions = contributions.length;
             for (uint256 i; i < numContributions; ++i) {
                 Contribution memory c = contributions[i];
-                if ( c.previousTotalContributions - c.previousTotalContributionsWithdrawn >= totalEthUsed) {
+                if (c.previousTotalContributions - c.previousTotalContributionsWithdrawn >= totalEthUsed) {
                     // This entire contribution was not used.
                     ethOwed += c.amount;
                 } else if (c.previousTotalContributions - c.previousTotalContributionsWithdrawn + c.amount <= totalEthUsed) {

--- a/contracts/crowdfund/Crowdfund.sol
+++ b/contracts/crowdfund/Crowdfund.sol
@@ -18,6 +18,7 @@ import "./CrowdfundNFT.sol";
 abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
     using LibRawResult for bytes;
     using LibSafeCast for uint256;
+    using LibSafeCast for  uint96;
     using LibAddress for address payable;
 
     enum CrowdfundLifecycle {
@@ -510,7 +511,7 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
             uint256 numContributions = contributions.length;
             for (uint256 i; i < numContributions; ++i) {
                 Contribution memory c = contributions[i];
-                if (c.previousTotalContributions >= totalEthUsed) {
+                if ( c.previousTotalContributions.safeCastUint96ToInt192() - totalContributionsWithdrawn.safeCastUint96ToInt192() >= int(totalEthUsed)) {
                     // This entire contribution was not used.
                     ethOwed += c.amount;
                 } else if (c.previousTotalContributions + c.amount <= totalEthUsed) {
@@ -518,9 +519,9 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
                     ethUsed += c.amount;
                 } else {
                     // This contribution was partially used.
-                    uint256 partialEthUsed = totalEthUsed - c.previousTotalContributions;
-                    ethUsed += partialEthUsed;
-                    ethOwed = c.amount - partialEthUsed;
+                        uint256 partialEthUsed = totalEthUsed - c.previousTotalContributions;
+                        ethUsed += partialEthUsed;
+                        ethOwed = c.amount - partialEthUsed;           
                 }
             }
         }
@@ -543,6 +544,7 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
         uint96 amount,
         address delegate,
         uint96 previousTotalContributions,
+        //previousTotalContributionsWithdrawn,
         bytes memory gateData
     ) private {
         // Require a non-null delegate.

--- a/contracts/crowdfund/Crowdfund.sol
+++ b/contracts/crowdfund/Crowdfund.sol
@@ -107,6 +107,7 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
         address delegate,
         uint256 previousTotalContributions
     );
+    event ContributorRageQuit(address contributor, uint256 ethReturned);
     event EmergencyExecute(address target, bytes data, uint256 amountEth);
     event EmergencyExecuteDisabled();
 

--- a/contracts/crowdfund/Crowdfund.sol
+++ b/contracts/crowdfund/Crowdfund.sol
@@ -317,8 +317,9 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
     }
 
     ///@notice Withdraw the funds of a contributor before a crowdfund is finalized.
-    function rageQuit() public onlyDelegateCall {
-        _rageQuit(msg.sender);
+    /// @param receiver The address to receive the NFT or refund.
+    function rageQuit(address payable receiver) public onlyDelegateCall {
+        _rageQuit(receiver);
     }
 
     /// @inheritdoc EIP165
@@ -607,7 +608,7 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
     }
 
     //Allows contributor to rage quit before crowdfund is finalized.
-    function _rageQuit(address contributor) private {
+    function _rageQuit(address payable contributor) private {
          // Only allow rage quit while the crowdfund is active.
          CrowdfundLifecycle lc = getCrowdfundLifecycle();
             if (lc != CrowdfundLifecycle.Active) {

--- a/contracts/crowdfund/Crowdfund.sol
+++ b/contracts/crowdfund/Crowdfund.sol
@@ -519,9 +519,9 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
                     ethUsed += c.amount;
                 } else {
                     // This contribution was partially used.
-                        uint256 partialEthUsed = totalEthUsed - c.previousTotalContributions;
-                        ethUsed += partialEthUsed;
-                        ethOwed = c.amount - partialEthUsed;           
+                    uint256 partialEthUsed = totalEthUsed - c.previousTotalContributions;
+                    ethUsed += partialEthUsed;
+                    ethOwed = c.amount - partialEthUsed;
                 }
             }
         }

--- a/contracts/crowdfund/Crowdfund.sol
+++ b/contracts/crowdfund/Crowdfund.sol
@@ -510,10 +510,10 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
             uint256 numContributions = contributions.length;
             for (uint256 i; i < numContributions; ++i) {
                 Contribution memory c = contributions[i];
-                if (c.previousTotalContributions - totalContributionsWithdrawn >= totalEthUsed) {
+                if (c.previousTotalContributions >= totalEthUsed) {
                     // This entire contribution was not used.
                     ethOwed += c.amount;
-                } else if (c.previousTotalContributions - totalContributionsWithdrawn + c.amount <= totalEthUsed) {
+                } else if (c.previousTotalContributions + c.amount <= totalEthUsed) {
                     // This entire contribution was used.
                     ethUsed += c.amount;
                 } else {

--- a/contracts/crowdfund/Crowdfund.sol
+++ b/contracts/crowdfund/Crowdfund.sol
@@ -610,6 +610,8 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
         totalContributions -= amountToRefund.safeCastUint256ToUint96();
         // Remove contributions entry for this contributor.
         delete _contributionsByContributor[contributor];
+        //burn crowdfundNFT
+        CrowdfundNFT._burn(contributor);
         //return the contribution amount
         contributor.transferEth(amountToRefund);
         emit ContributorRageQuit(contributor, amountToRefund);

--- a/contracts/crowdfund/Crowdfund.sol
+++ b/contracts/crowdfund/Crowdfund.sol
@@ -479,6 +479,17 @@ abstract contract Crowdfund is Implementation, ERC721Receiver, CrowdfundNFT {
         }
     }
 
+    function _getCurrentContribution(address contributor) internal view returns (uint256 ethOwed) {
+        {
+    Contribution[] memory contributions = _contributionsByContributor[contributor];
+    uint256 numContributions = contributions.length;
+    for (uint256 i; i < numContributions; ++i) {
+        Contribution memory c = contributions[i];
+        ethOwed += c.amount;
+            }
+        }
+    }
+
     function _getFinalContribution(
         address contributor
     ) internal view returns (uint256 ethUsed, uint256 ethOwed, uint256 votingPower) {

--- a/sol-tests/crowdfund/AuctionCrowdfund.t.sol
+++ b/sol-tests/crowdfund/AuctionCrowdfund.t.sol
@@ -36,7 +36,8 @@ contract AuctionCrowdfundTest is Test, TestUtils {
         address contributor,
         uint256 amount,
         address delegate,
-        uint256 previousTotalContributions
+        uint256 previousTotalContributions,
+        uint256 previousTotalContributionsWithdrawn
     );
     event Won(uint256 bid, Party party);
     event Lost();
@@ -126,9 +127,11 @@ contract AuctionCrowdfundTest is Test, TestUtils {
             );
     }
 
-    function _createExpectedPartyOptions(
-        uint256 finalPrice
-    ) private view returns (Party.PartyOptions memory opts) {
+    function _createExpectedPartyOptions(uint256 finalPrice)
+        private
+        view
+        returns (Party.PartyOptions memory opts)
+    {
         return
             Party.PartyOptions({
                 name: defaultName,
@@ -707,7 +710,7 @@ contract AuctionCrowdfundTest is Test, TestUtils {
         address initialContributor = _randomAddress();
         address initialDelegate = _randomAddress();
         vm.deal(address(this), initialContribution);
-        emit Contributed(initialContributor, initialContribution, initialDelegate, 0);
+        emit Contributed(initialContributor, initialContribution, initialDelegate, 0, 0);
         AuctionCrowdfund(
             payable(
                 address(
@@ -741,7 +744,11 @@ contract AuctionCrowdfundTest is Test, TestUtils {
         );
     }
 
-    function _contribute(AuctionCrowdfund cf, address contributor, uint256 amount) private {
+    function _contribute(
+        AuctionCrowdfund cf,
+        address contributor,
+        uint256 amount
+    ) private {
         vm.deal(contributor, amount);
         vm.prank(contributor);
         cf.contribute{ value: amount }(contributor, "");
@@ -754,10 +761,17 @@ contract AuctionCrowdfundTest is Test, TestUtils {
         uint256 amount
     ) private {
         uint256 previousTotalContributions = cf.totalContributions();
+        uint256 previousTotalContributionsWithdrawn = 0;
         vm.deal(contributor, amount);
         vm.prank(contributor);
         _expectEmit0();
-        emit Contributed(contributor, amount, delegate, previousTotalContributions);
+        emit Contributed(
+            contributor,
+            amount,
+            delegate,
+            previousTotalContributions,
+            previousTotalContributionsWithdrawn
+        );
         cf.contribute{ value: amount }(delegate, "");
     }
 

--- a/sol-tests/crowdfund/AuctionCrowdfund.t.sol
+++ b/sol-tests/crowdfund/AuctionCrowdfund.t.sol
@@ -127,11 +127,9 @@ contract AuctionCrowdfundTest is Test, TestUtils {
             );
     }
 
-    function _createExpectedPartyOptions(uint256 finalPrice)
-        private
-        view
-        returns (Party.PartyOptions memory opts)
-    {
+    function _createExpectedPartyOptions(
+        uint256 finalPrice
+    ) private view returns (Party.PartyOptions memory opts) {
         return
             Party.PartyOptions({
                 name: defaultName,
@@ -743,12 +741,7 @@ contract AuctionCrowdfundTest is Test, TestUtils {
             )
         );
     }
-
-    function _contribute(
-        AuctionCrowdfund cf,
-        address contributor,
-        uint256 amount
-    ) private {
+ function _contribute(AuctionCrowdfund cf, address contributor, uint256 amount) private {
         vm.deal(contributor, amount);
         vm.prank(contributor);
         cf.contribute{ value: amount }(contributor, "");

--- a/sol-tests/crowdfund/CollectionBuyCrowdfund.t.sol
+++ b/sol-tests/crowdfund/CollectionBuyCrowdfund.t.sol
@@ -30,7 +30,8 @@ contract CollectionBuyCrowdfundTest is Test, TestUtils {
         address contributor,
         uint256 amount,
         address delegate,
-        uint256 previousTotalContributions
+        uint256 previousTotalContributions,
+        uint256 previousToatalContributionsWithdrawn
     );
 
     string defaultName = "CollectionBuyCrowdfund";
@@ -56,10 +57,7 @@ contract CollectionBuyCrowdfundTest is Test, TestUtils {
         collectionBuyCrowdfundImpl = new CollectionBuyCrowdfund(globals);
     }
 
-    function _createCrowdfund(
-        address[] memory hosts,
-        uint96 initialContribution
-    )
+    function _createCrowdfund(address[] memory hosts, uint96 initialContribution)
         private
         returns (CollectionBuyCrowdfund cf, Crowdfund.FixedGovernanceOpts memory governanceOpts)
     {
@@ -94,10 +92,11 @@ contract CollectionBuyCrowdfundTest is Test, TestUtils {
         );
     }
 
-    function _createExpectedPartyOptions(
-        address[] memory hosts,
-        uint256 finalPrice
-    ) private view returns (Party.PartyOptions memory opts) {
+    function _createExpectedPartyOptions(address[] memory hosts, uint256 finalPrice)
+        private
+        view
+        returns (Party.PartyOptions memory opts)
+    {
         return
             Party.PartyOptions({
                 name: defaultName,
@@ -232,7 +231,7 @@ contract CollectionBuyCrowdfundTest is Test, TestUtils {
         defaultGovernanceOpts.hosts = _toAddressArray(_randomAddress());
         vm.deal(address(this), initialContribution);
         _expectEmit0();
-        emit Contributed(initialContributor, initialContribution, initialDelegate, 0);
+        emit Contributed(initialContributor, initialContribution, initialDelegate, 0, 0);
         CollectionBuyCrowdfund(
             payable(
                 address(

--- a/sol-tests/crowdfund/CollectionBuyCrowdfund.t.sol
+++ b/sol-tests/crowdfund/CollectionBuyCrowdfund.t.sol
@@ -94,10 +94,10 @@ contract CollectionBuyCrowdfundTest is Test, TestUtils {
         );
     }
 
-       function _createExpectedPartyOptions(
-           address[] memory hosts,
-           uint256 finalPrice
-       ) private view returns (Party.PartyOptions memory opts) {
+    function _createExpectedPartyOptions(
+        address[] memory hosts,
+        uint256 finalPrice
+    ) private view returns (Party.PartyOptions memory opts) {
         return
             Party.PartyOptions({
                 name: defaultName,

--- a/sol-tests/crowdfund/CollectionBuyCrowdfund.t.sol
+++ b/sol-tests/crowdfund/CollectionBuyCrowdfund.t.sol
@@ -56,8 +56,10 @@ contract CollectionBuyCrowdfundTest is Test, TestUtils {
         party = partyFactory.mockParty();
         collectionBuyCrowdfundImpl = new CollectionBuyCrowdfund(globals);
     }
-
-    function _createCrowdfund(address[] memory hosts, uint96 initialContribution)
+    function _createCrowdfund(
+        address[] memory hosts,
+        uint96 initialContribution
+    )
         private
         returns (CollectionBuyCrowdfund cf, Crowdfund.FixedGovernanceOpts memory governanceOpts)
     {
@@ -92,11 +94,10 @@ contract CollectionBuyCrowdfundTest is Test, TestUtils {
         );
     }
 
-    function _createExpectedPartyOptions(address[] memory hosts, uint256 finalPrice)
-        private
-        view
-        returns (Party.PartyOptions memory opts)
-    {
+       function _createExpectedPartyOptions(
+           address[] memory hosts,
+           uint256 finalPrice
+       ) private view returns (Party.PartyOptions memory opts) {
         return
             Party.PartyOptions({
                 name: defaultName,

--- a/sol-tests/crowdfund/Crowdfund.t.sol
+++ b/sol-tests/crowdfund/Crowdfund.t.sol
@@ -169,9 +169,9 @@ contract CrowdfundTest is Test, TestUtils {
         return _createCrowdfund(initialContribution, address(this), defaultInitialDelegate, 0);
     }
 
- function _createExpectedPartyOptions(
-     TestableCrowdfund cf,
-     uint256 finalPrice
+    function _createExpectedPartyOptions(
+        TestableCrowdfund cf,
+        uint256 finalPrice
     ) private view returns (Party.PartyOptions memory opts) {
         Crowdfund.FixedGovernanceOpts memory govOpts = cf.getFixedGovernanceOpts();
         return

--- a/sol-tests/crowdfund/Crowdfund.t.sol
+++ b/sol-tests/crowdfund/Crowdfund.t.sol
@@ -1065,30 +1065,44 @@ contract CrowdfundTest is Test, TestUtils {
         TestableCrowdfund cf = _createCrowdfund(0);
         address delegate1 = _randomAddress();
         address delegate2 = _randomAddress();
+        address delegate3 = _randomAddress();
         address payable contributor1 = _randomAddress();
         address payable contributor2 = _randomAddress();
+        address payable contributor3 = _randomAddress();
+
         // contributor1 contributes 1 ETH
         vm.deal(contributor1, 1e18);
         vm.prank(contributor1);
         cf.contribute{ value: contributor1.balance }(delegate1, "");
-        // contributor2 contributes 0.5 ETH
-        vm.deal(contributor2, 0.5e18);
+        // contributor2 contributes 9 ETH
+        vm.deal(contributor2, 10e18);
         vm.prank(contributor2);
         cf.contribute{ value: contributor2.balance }(delegate2, "");
-        assertEq(cf.totalContributions(), 1.5e18);
-        //contributor2 withdraws 0.5 ETH
+        assertEq(cf.totalContributions(), 11e18);
+        vm.deal(contributor3, 1e18);
+        vm.prank(contributor3);
+        cf.contribute{ value: 0.5e18 }(delegate3, "");
+        assertEq(cf.totalContributions(), 11.5e18);
+        //contributor2 withdraws 9 ETH
         cf.rageQuit(contributor2);
+        cf.contribute{ value: 0.5e18 }(delegate3, "");
+        assertEq(cf.totalContributions(), 2e18);
         // set up a loss
         cf.testSetLifeCycle(Crowdfund.CrowdfundLifecycle.Lost);
         assertEq(address(cf.party()), address(0));
         // contributor1 burns tokens
-        vm.expectEmit(false, false, false, true);
+        // vm.expectEmit(false, false, false, true);
         emit Burned(contributor1, 0, 1e18, 0);
         cf.burn(contributor1);
         // contributor1 gets back their contribution
         assertEq(contributor1.balance, 1e18);
+        // contributor3 burns tokens
+        // vm.expectEmit(false, false, false, true);
+        emit Burned(contributor3, 0, 1e18, 0);
+        cf.burn(contributor3);
+        assertEq(contributor3.balance, 1e18);
         // contributor2 balance remains the same
-        assertEq(contributor2.balance, 0.5e18);
+        assertEq(contributor2.balance, 10e18);
     }
 
     function test_canEmergencyExecute() external {

--- a/sol-tests/crowdfund/Crowdfund.t.sol
+++ b/sol-tests/crowdfund/Crowdfund.t.sol
@@ -984,9 +984,7 @@ contract CrowdfundTest is Test, TestUtils {
         assertEq(cf.getContributionEntriesByContributorCount(contributor), 1);
         //rageQuit crowdfund.
         cf.rageQuit(contributor);
-        //check totalContributions was updated correctly.
-        assertEq(cf.totalContributions(), 0);
-        //check that contributor's eth was returned.
+        //check that contributor's ETH was returned.
         assertEq(contributor.balance, 3);
     }
 
@@ -1003,21 +1001,17 @@ contract CrowdfundTest is Test, TestUtils {
         assertEq(cf.getContributionEntriesByContributorCount(contributor1), 1);
         //rageQuit crowdfund.
         cf.rageQuit(contributor1);
-        //check totalContributions was updated correctly.
-        assertEq(cf.totalContributions(), 0);
         //check that contributor's eth was returned.
         assertEq(contributor1.balance, 3);
         //contributor2 contributes
         vm.prank(contributor2);
         cf.contribute{ value: 10 }(contributor2, "");
-        assertEq(cf.totalContributions(), 10);
+        assertEq(cf.totalContributions(), 11);
         //contributor calls ragequit a second time.
         vm.prank(contributor1);
         cf.rageQuit(contributor1);
         //check contributor balance does not increase.
         assertEq(contributor1.balance, 3);
-        //check total contributions remains the same.
-        assertEq(cf.totalContributions(), 10);
     }
 
     function test_win_afterWithdrawnContribution() external {
@@ -1030,14 +1024,12 @@ contract CrowdfundTest is Test, TestUtils {
         // contributor1 contributes 1 ETH
         vm.prank(contributor1);
         cf.contribute{ value: contributor1.balance }(delegate1, "");
-        //assertEq(cf.totalContributions(), 10);
         // contributor2 contributes 10 ETH
         vm.prank(contributor2);
         cf.contribute{ value: contributor2.balance }(delegate1, "");
         assertEq(cf.totalContributions(), 16e18);
         // contributor2 withdraws ETH
         cf.rageQuit(contributor2);
-        assertEq(cf.totalContributions(), 15e18);
         // set up a win using contributor1's total contribution
         (IERC721[] memory erc721Tokens, uint256[] memory erc721TokenIds) = _createTokens(
             address(cf),
@@ -1086,7 +1078,6 @@ contract CrowdfundTest is Test, TestUtils {
         //contributor2 withdraws 9 ETH
         cf.rageQuit(contributor2);
         cf.contribute{ value: 0.5e18 }(delegate3, "");
-        assertEq(cf.totalContributions(), 2e18);
         // set up a loss
         cf.testSetLifeCycle(Crowdfund.CrowdfundLifecycle.Lost);
         assertEq(address(cf.party()), address(0));

--- a/sol-tests/crowdfund/Crowdfund.t.sol
+++ b/sol-tests/crowdfund/Crowdfund.t.sol
@@ -45,7 +45,8 @@ contract CrowdfundTest is Test, TestUtils {
         address contributor,
         uint256 amount,
         address delegate,
-        uint256 previousTotalContributions
+        uint256 previousTotalContributions,
+        uint256 previousTotalContributionsWithdrawn
     );
     event Burned(address contributor, uint256 ethUsed, uint256 ethOwed, uint256 votingPower);
     event EmergencyExecuteTargetCalled();
@@ -213,7 +214,7 @@ contract CrowdfundTest is Test, TestUtils {
         address initialDelegate = _randomAddress();
         uint256 initialContribution = _randomRange(1, 1 ether);
         vm.deal(address(this), initialContribution);
-        emit Contributed(initialContributor, initialContribution, initialDelegate, 0);
+        emit Contributed(initialContributor, initialContribution, initialDelegate, 0, 0);
         TestableCrowdfund cf = _createCrowdfund(
             initialContribution,
             initialContributor,

--- a/sol-tests/crowdfund/Crowdfund.t.sol
+++ b/sol-tests/crowdfund/Crowdfund.t.sol
@@ -107,10 +107,10 @@ contract CrowdfundTest is Test, TestUtils {
         }
     }
 
-    function _createTokens(
-        address owner,
-        uint256 count
-    ) private returns (IERC721[] memory tokens, uint256[] memory tokenIds) {
+    function _createTokens(address owner, uint256 count)
+        private
+        returns (IERC721[] memory tokens, uint256[] memory tokenIds)
+    {
         tokens = new IERC721[](count);
         tokenIds = new uint256[](count);
         for (uint256 i; i < count; ++i) {
@@ -152,10 +152,10 @@ contract CrowdfundTest is Test, TestUtils {
         );
     }
 
-    function _createCrowdfund(
-        uint256 initialContribution,
-        uint256 customizationPresetId
-    ) private returns (TestableCrowdfund cf) {
+    function _createCrowdfund(uint256 initialContribution, uint256 customizationPresetId)
+        private
+        returns (TestableCrowdfund cf)
+    {
         return
             _createCrowdfund(
                 initialContribution,
@@ -169,10 +169,11 @@ contract CrowdfundTest is Test, TestUtils {
         return _createCrowdfund(initialContribution, address(this), defaultInitialDelegate, 0);
     }
 
-    function _createExpectedPartyOptions(
-        TestableCrowdfund cf,
-        uint256 finalPrice
-    ) private view returns (Party.PartyOptions memory opts) {
+    function _createExpectedPartyOptions(TestableCrowdfund cf, uint256 finalPrice)
+        private
+        view
+        returns (Party.PartyOptions memory opts)
+    {
         Crowdfund.FixedGovernanceOpts memory govOpts = cf.getFixedGovernanceOpts();
         return
             Party.PartyOptions({
@@ -195,10 +196,11 @@ contract CrowdfundTest is Test, TestUtils {
         return (uint256(1e4 - defaultSplitBps) * contribution) / 1e4;
     }
 
-    function _getAmountWithSplit(
-        uint256 contribution,
-        uint256 totalContributions
-    ) private view returns (uint256 r) {
+    function _getAmountWithSplit(uint256 contribution, uint256 totalContributions)
+        private
+        view
+        returns (uint256 r)
+    {
         return
             _getAmountWithoutSplit(contribution) +
             (uint256(defaultSplitBps) * totalContributions + (1e4 - 1)) /
@@ -970,6 +972,23 @@ contract CrowdfundTest is Test, TestUtils {
         cf.contribute{ value: 2 }(contributor1, "");
         assertEq(cf.totalContributions(), 13);
         assertEq(cf.getContributionEntriesByContributorCount(contributor1), 2);
+    }
+
+    function test_canWithdrawContribution() external {
+        TestableCrowdfund cf = _createCrowdfund(0);
+        address contributor = _randomAddress();
+
+        vm.deal(contributor, 3);
+        vm.prank(contributor);
+        cf.contribute{ value: 1 }(contributor, "");
+        assertEq(cf.totalContributions(), 1);
+        assertEq(cf.getContributionEntriesByContributorCount(contributor), 1);
+        //rageQuit crowdfund.
+        cf.rageQuit();
+        //check totalContributions was updated correctly
+        assertEq(cf.totalContributions(), 0);
+        //check that contributor's eth was returned.
+        assertEq(contributor.balance, 3);
     }
 
     function test_canEmergencyExecute() external {

--- a/sol-tests/crowdfund/Crowdfund.t.sol
+++ b/sol-tests/crowdfund/Crowdfund.t.sol
@@ -107,11 +107,10 @@ contract CrowdfundTest is Test, TestUtils {
             );
         }
     }
-
-    function _createTokens(address owner, uint256 count)
-        private
-        returns (IERC721[] memory tokens, uint256[] memory tokenIds)
-    {
+    function _createTokens(
+        address owner,
+        uint256 count
+    ) private returns (IERC721[] memory tokens, uint256[] memory tokenIds) {
         tokens = new IERC721[](count);
         tokenIds = new uint256[](count);
         for (uint256 i; i < count; ++i) {
@@ -153,10 +152,10 @@ contract CrowdfundTest is Test, TestUtils {
         );
     }
 
-    function _createCrowdfund(uint256 initialContribution, uint256 customizationPresetId)
-        private
-        returns (TestableCrowdfund cf)
-    {
+    function _createCrowdfund(
+        uint256 initialContribution,
+        uint256 customizationPresetId
+    ) private returns (TestableCrowdfund cf) {
         return
             _createCrowdfund(
                 initialContribution,
@@ -170,11 +169,10 @@ contract CrowdfundTest is Test, TestUtils {
         return _createCrowdfund(initialContribution, address(this), defaultInitialDelegate, 0);
     }
 
-    function _createExpectedPartyOptions(TestableCrowdfund cf, uint256 finalPrice)
-        private
-        view
-        returns (Party.PartyOptions memory opts)
-    {
+ function _createExpectedPartyOptions(
+     TestableCrowdfund cf,
+     uint256 finalPrice
+    ) private view returns (Party.PartyOptions memory opts) {
         Crowdfund.FixedGovernanceOpts memory govOpts = cf.getFixedGovernanceOpts();
         return
             Party.PartyOptions({
@@ -197,11 +195,10 @@ contract CrowdfundTest is Test, TestUtils {
         return (uint256(1e4 - defaultSplitBps) * contribution) / 1e4;
     }
 
-    function _getAmountWithSplit(uint256 contribution, uint256 totalContributions)
-        private
-        view
-        returns (uint256 r)
-    {
+    function _getAmountWithSplit(
+        uint256 contribution,
+        uint256 totalContributions
+    ) private view returns (uint256 r) {
         return
             _getAmountWithoutSplit(contribution) +
             (uint256(defaultSplitBps) * totalContributions + (1e4 - 1)) /


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
This feature gives a contributor to a party the ability to rage quit(withdraw 100% of their contribution) before a crowdfund is finalized.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
A `rageQuit` function has been created that increases a new variable `totalContributionsWithdrawn`, and removes the `_contributionsByContributor ` mapping for the user who quit.  The function also returns the quitting user's total contribution to the crowdfund. 

`previousTotalContributionsWithdrawn` has been added to the `Contribution` struct for proper accounting in the `_getFinalContribution` function 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
