### PR TITLE
add helper for getting info on batches

### DIFF
--- a/contracts/utils/PartyHelpers.sol
+++ b/contracts/utils/PartyHelpers.sol
@@ -121,4 +121,26 @@ contract PartyHelpers {
             });
         }
     }
+
+
+    /// @notice Get the owner and intrinsic voting power of each governance nft in a list
+    function getNftInfosRange(
+        address party,
+        uint256[] memory tokenIds
+    ) external view returns (NftInfo[] memory nftInfos) {
+        Party p = Party(payable(party));
+        uint256 numTokens = tokenIds.length;
+        nftInfos = new NftInfo[](numTokens);
+
+        for (uint256 i; i < numTokens; ++i) {
+            uint256 currItem = tokenIds[i];
+            address owner = p.ownerOf(currItem);
+            uint256 intrinsicVotingPower = p.votingPowerByTokenId(currItem);
+            nftInfos[i] = NftInfo({
+                intrinsicVotingPower: intrinsicVotingPower,
+                owner: owner,
+                tokenId: currItem
+            });
+        }
+    }
 }

--- a/contracts/utils/PartyHelpers.sol
+++ b/contracts/utils/PartyHelpers.sol
@@ -124,7 +124,7 @@ contract PartyHelpers {
 
 
     /// @notice Get the owner and intrinsic voting power of each governance nft in a list
-    function getNftInfosRange(
+    function getNftInfosBatch(
         address party,
         uint256[] memory tokenIds
     ) external view returns (NftInfo[] memory nftInfos) {

--- a/contracts/utils/PartyHelpers.sol
+++ b/contracts/utils/PartyHelpers.sol
@@ -95,14 +95,13 @@ contract PartyHelpers {
 
     /// @notice Get the owner and intrinsic voting power of each governance nft in a range
     function getNftInfos(
-        address party,
+        Party party,
         uint256 startTokenId,
         uint256 endTokenId
     ) external view returns (NftInfo[] memory nftInfos) {
-        Party p = Party(payable(party));
         uint256 count = endTokenId - startTokenId + 1;
         {
-            uint256 tokenCount = p.tokenCount();
+            uint256 tokenCount = party.tokenCount();
             if (count > tokenCount) {
                 count = tokenCount + 1 - startTokenId;
             }
@@ -112,8 +111,8 @@ contract PartyHelpers {
 
         for (uint256 i; i < count; ++i) {
             uint256 currIndex = startTokenId + i;
-            address owner = p.ownerOf(currIndex);
-            uint256 intrinsicVotingPower = p.votingPowerByTokenId(currIndex);
+            address owner = party.ownerOf(currIndex);
+            uint256 intrinsicVotingPower = party.votingPowerByTokenId(currIndex);
             nftInfos[i] = NftInfo({
                 intrinsicVotingPower: intrinsicVotingPower,
                 owner: owner,
@@ -122,20 +121,18 @@ contract PartyHelpers {
         }
     }
 
-
     /// @notice Get the owner and intrinsic voting power of each governance nft in a list
     function getNftInfosBatch(
-        address party,
+        Party party,
         uint256[] memory tokenIds
     ) external view returns (NftInfo[] memory nftInfos) {
-        Party p = Party(payable(party));
         uint256 numTokens = tokenIds.length;
         nftInfos = new NftInfo[](numTokens);
 
         for (uint256 i; i < numTokens; ++i) {
             uint256 currItem = tokenIds[i];
-            address owner = p.ownerOf(currItem);
-            uint256 intrinsicVotingPower = p.votingPowerByTokenId(currItem);
+            address owner = party.ownerOf(currItem);
+            uint256 intrinsicVotingPower = party.votingPowerByTokenId(currItem);
             nftInfos[i] = NftInfo({
                 intrinsicVotingPower: intrinsicVotingPower,
                 owner: owner,

--- a/sol-tests/utils/PartyGovernanceHelpers.t.sol
+++ b/sol-tests/utils/PartyGovernanceHelpers.t.sol
@@ -183,12 +183,12 @@ contract PartyGovernanceHelpersTest is Test, TestUtils {
         partyAdmin.mintGovNft(party, address(lawrence), 20, address(lawrence));
         partyAdmin.mintGovNft(party, address(anna), 35, address(anna));
 
-        // test getNftInfosRange
+        // test getNftInfosBatch
         uint256[] memory items = new uint256[](3);
         items[0] = 3;
         items[1] = 2;
         items[2] = 1;
-        PartyHelpers.NftInfo[] memory nftInfos0 = ph.getNftInfosRange(address(party), items);
+        PartyHelpers.NftInfo[] memory nftInfos0 = ph.getNftInfosBatch(address(party), items);
         assertTrue(nftInfos0[0].tokenId == 3);
         assertTrue(nftInfos0[0].owner == address(lawrence));
         assertTrue(nftInfos0[0].intrinsicVotingPower == 20);

--- a/sol-tests/utils/PartyGovernanceHelpers.t.sol
+++ b/sol-tests/utils/PartyGovernanceHelpers.t.sol
@@ -183,6 +183,22 @@ contract PartyGovernanceHelpersTest is Test, TestUtils {
         partyAdmin.mintGovNft(party, address(lawrence), 20, address(lawrence));
         partyAdmin.mintGovNft(party, address(anna), 35, address(anna));
 
+        // test getNftInfosRange
+        uint256[] memory items = new uint256[](3);
+        items[0] = 3;
+        items[1] = 2;
+        items[2] = 1;
+        PartyHelpers.NftInfo[] memory nftInfos0 = ph.getNftInfosRange(address(party), items);
+        assertTrue(nftInfos0[0].tokenId == 3);
+        assertTrue(nftInfos0[0].owner == address(lawrence));
+        assertTrue(nftInfos0[0].intrinsicVotingPower == 20);
+        assertTrue(nftInfos0[1].tokenId == 2);
+        assertTrue(nftInfos0[1].owner == address(steve));
+        assertTrue(nftInfos0[1].intrinsicVotingPower == 15);
+        assertTrue(nftInfos0[2].tokenId == 1);
+        assertTrue(nftInfos0[2].owner == address(john));
+        assertTrue(nftInfos0[2].intrinsicVotingPower == 30);
+
         // test endIndex > tokenCount
         PartyHelpers.NftInfo[] memory nftInfos = ph.getNftInfos(address(party), 1, 6);
         assertTrue(nftInfos.length == 4);

--- a/sol-tests/utils/PartyGovernanceHelpers.t.sol
+++ b/sol-tests/utils/PartyGovernanceHelpers.t.sol
@@ -174,7 +174,7 @@ contract PartyGovernanceHelpersTest is Test, TestUtils {
         PartyHelpers ph = new PartyHelpers();
 
         // test tokenCount = 0
-        PartyHelpers.NftInfo[] memory emptyNftInfo = ph.getNftInfos(address(party), 1, 6);
+        PartyHelpers.NftInfo[] memory emptyNftInfo = ph.getNftInfos(party, 1, 6);
         assertTrue(emptyNftInfo.length == 0);
 
         // Mint first governance NFTs
@@ -188,7 +188,7 @@ contract PartyGovernanceHelpersTest is Test, TestUtils {
         items[0] = 3;
         items[1] = 2;
         items[2] = 1;
-        PartyHelpers.NftInfo[] memory nftInfos0 = ph.getNftInfosBatch(address(party), items);
+        PartyHelpers.NftInfo[] memory nftInfos0 = ph.getNftInfosBatch(party, items);
         assertTrue(nftInfos0[0].tokenId == 3);
         assertTrue(nftInfos0[0].owner == address(lawrence));
         assertTrue(nftInfos0[0].intrinsicVotingPower == 20);
@@ -200,7 +200,7 @@ contract PartyGovernanceHelpersTest is Test, TestUtils {
         assertTrue(nftInfos0[2].intrinsicVotingPower == 30);
 
         // test endIndex > tokenCount
-        PartyHelpers.NftInfo[] memory nftInfos = ph.getNftInfos(address(party), 1, 6);
+        PartyHelpers.NftInfo[] memory nftInfos = ph.getNftInfos(party, 1, 6);
         assertTrue(nftInfos.length == 4);
         assertTrue(nftInfos[0].tokenId == 1);
         assertTrue(nftInfos[0].owner == address(john));
@@ -216,14 +216,14 @@ contract PartyGovernanceHelpersTest is Test, TestUtils {
         assertTrue(nftInfos[3].intrinsicVotingPower == 35);
 
         // test expected startTokenId and endTokenId
-        PartyHelpers.NftInfo[] memory nftInfos2 = ph.getNftInfos(address(party), 1, 1);
+        PartyHelpers.NftInfo[] memory nftInfos2 = ph.getNftInfos(party, 1, 1);
         assertTrue(nftInfos2.length == 1);
         assertTrue(nftInfos2[0].tokenId == 1);
         assertTrue(nftInfos2[0].owner == address(john));
         assertTrue(nftInfos2[0].intrinsicVotingPower == 30);
 
         // test startTokenId > 1
-        PartyHelpers.NftInfo[] memory nftInfos3 = ph.getNftInfos(address(party), 2, 4);
+        PartyHelpers.NftInfo[] memory nftInfos3 = ph.getNftInfos(party, 2, 4);
         assertTrue(nftInfos3.length == 3);
         assertTrue(nftInfos3[0].tokenId == 2);
         assertTrue(nftInfos3[0].owner == address(steve));
@@ -236,7 +236,7 @@ contract PartyGovernanceHelpersTest is Test, TestUtils {
         assertTrue(nftInfos3[2].intrinsicVotingPower == 35);
 
         // test startTokenId > 1 and endTokenId > tokenCount
-        PartyHelpers.NftInfo[] memory nftInfos4 = ph.getNftInfos(address(party), 2, 6);
+        PartyHelpers.NftInfo[] memory nftInfos4 = ph.getNftInfos(party, 2, 6);
         assertTrue(nftInfos4.length == 3);
         assertTrue(nftInfos4[0].tokenId == 2);
         assertTrue(nftInfos4[0].owner == address(steve));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Adds helper function to get nft infos by specific batches instead of ranges.  Helpful for future when tokens are burned.

## Solution

Introduce helper & tests