### PR TITLE
refactor: migrate from zora v2 to v3

### DIFF
--- a/contracts/proposals/ArbitraryCallsProposal.sol
+++ b/contracts/proposals/ArbitraryCallsProposal.sol
@@ -6,7 +6,7 @@ import "../tokens/IERC721Receiver.sol";
 import "../tokens/ERC1155Receiver.sol";
 import "../utils/LibSafeERC721.sol";
 import "../utils/LibAddress.sol";
-import "../vendor/markets/IZoraAuctionHouse.sol";
+import "../vendor/markets/IReserveAuctionCoreEth.sol";
 import "./vendor/IOpenseaExchange.sol";
 
 import "./LibProposal.sol";
@@ -43,9 +43,9 @@ contract ArbitraryCallsProposal {
 
     event ArbitraryCallExecuted(uint256 proposalId, uint256 idx, uint256 count);
 
-    IZoraAuctionHouse private immutable _ZORA;
+    IReserveAuctionCoreEth private immutable _ZORA;
 
-    constructor(IZoraAuctionHouse zora) {
+    constructor(IReserveAuctionCoreEth zora) {
         _ZORA = zora;
     }
 
@@ -206,7 +206,7 @@ contract ArbitraryCallsProposal {
                     }
                     // Can only call cancelAuction on the zora AH if it's the last call
                     // in the sequence.
-                } else if (selector == IZoraAuctionHouse.cancelAuction.selector) {
+                } else if (selector == IReserveAuctionCoreEth.cancelAuction.selector) {
                     if (call.target == address(_ZORA)) {
                         return callIndex + 1 == callsCount;
                     }

--- a/contracts/proposals/ListOnOpenseaAdvancedProposal.sol
+++ b/contracts/proposals/ListOnOpenseaAdvancedProposal.sol
@@ -163,11 +163,11 @@ abstract contract ListOnOpenseaAdvancedProposal is OpenseaHelpers, ZoraHelpers {
                     _GLOBALS.getUint256(LibGlobals.GLOBAL_OS_ZORA_AUCTION_DURATION)
                 );
                 if (zoraTimeout != 0) {
-                    uint256 auctionId = _createZoraAuction(
+                    _createZoraAuction(
                         data.startPrice,
                         zoraTimeout,
                         zoraDuration,
-                        IERC721(data.token),
+                        data.token,
                         data.tokenId
                     );
                     // Return the next step and data required to execute that step.
@@ -175,7 +175,6 @@ abstract contract ListOnOpenseaAdvancedProposal is OpenseaHelpers, ZoraHelpers {
                         abi.encode(
                             ListOnOpenseaStep.ListedOnZora,
                             ZoraProgressData({
-                                auctionId: auctionId,
                                 minExpiry: (block.timestamp + zoraTimeout).safeCastUint256ToUint40()
                             })
                         );
@@ -196,9 +195,8 @@ abstract contract ListOnOpenseaAdvancedProposal is OpenseaHelpers, ZoraHelpers {
             // Try to settle the Zora auction. This will revert if the auction
             // is still ongoing.
             ZoraAuctionStatus statusCode = _settleZoraAuction(
-                zpd.auctionId,
                 zpd.minExpiry,
-                IERC721(data.token),
+                data.token,
                 data.tokenId
             );
             if (statusCode == ZoraAuctionStatus.Sold || statusCode == ZoraAuctionStatus.Cancelled) {

--- a/contracts/proposals/ListOnZoraProposal.sol
+++ b/contracts/proposals/ListOnZoraProposal.sol
@@ -8,7 +8,7 @@ import "../utils/LibRawResult.sol";
 import "../utils/LibSafeERC721.sol";
 import "../utils/LibSafeCast.sol";
 
-import "../vendor/markets/IZoraAuctionHouse.sol";
+import { IReserveAuctionCoreEth } from "../vendor/markets/IReserveAuctionCoreEth.sol";
 import "./IProposalExecutionEngine.sol";
 import "./ZoraHelpers.sol";
 
@@ -35,39 +35,32 @@ contract ListOnZoraProposal is ZoraHelpers {
         // How long the auction lasts once a person bids on it.
         uint40 duration;
         // The token contract of the NFT being listed.
-        IERC721 token;
+        address token;
         // The token ID of the NFT being listed.
         uint256 tokenId;
     }
 
-    error ZoraListingNotExpired(uint256 auctionId, uint40 expiry);
+    error ZoraListingNotExpired(address token, uint256 tokenid, uint40 expiry);
+    error ZoraListingLive(address token, uint256 tokenId, uint256 auctionEndTime);
 
     event ZoraAuctionCreated(
-        uint256 auctionId,
-        IERC721 token,
+        address token,
         uint256 tokenId,
         uint256 startingPrice,
         uint40 duration,
         uint40 timeoutTime
     );
-    event ZoraAuctionExpired(uint256 auctionId, uint256 expiry);
-    event ZoraAuctionSold(uint256 auctionId);
-    event ZoraAuctionFailed(uint256 auctionId);
+    event ZoraAuctionExpired(address token, uint256 tokenid, uint256 expiry);
+    event ZoraAuctionSold(address token, uint256 tokenid);
 
-    // keccak256(abi.encodeWithSignature('Error(string)', "Auction hasn't begun"))
-    bytes32 internal constant AUCTION_HASNT_BEGUN_ERROR_HASH =
-        0x54a53788b7942d79bb6fcd40012c5e867208839fa1607e1f245558ee354e9565;
-    // keccak256(abi.encodeWithSignature('Error(string)', "Auction doesn't exit"))
-    bytes32 internal constant AUCTION_DOESNT_EXIST_ERROR_HASH =
-        0x474ba0184a7cd5de777156a56f3859150719340a6974b6ee50f05c58139f4dc2;
     /// @notice Zora auction house contract.
-    IZoraAuctionHouse public immutable ZORA;
+    IReserveAuctionCoreEth public immutable ZORA;
     // The `Globals` contract storing global configuration values. This contract
     // is immutable and it’s address will never change.
     IGlobals private immutable _GLOBALS;
 
     // Set immutables.
-    constructor(IGlobals globals, IZoraAuctionHouse zoraAuctionHouse) {
+    constructor(IGlobals globals, IReserveAuctionCoreEth zoraAuctionHouse) {
         ZORA = zoraAuctionHouse;
         _GLOBALS = globals;
     }
@@ -79,7 +72,7 @@ contract ListOnZoraProposal is ZoraHelpers {
         IProposalExecutionEngine.ExecuteProposalParams memory params
     ) internal returns (bytes memory nextProgressData) {
         ZoraProposalData memory data = abi.decode(params.proposalData, (ZoraProposalData));
-        // If there is progressData passed in, we're on the first step,
+        // If there is no progressData passed in, we're on the first step,
         // otherwise parse the first word of the progressData as the current step.
         ZoraStep step = params.progressData.length == 0
             ? ZoraStep.None
@@ -108,7 +101,7 @@ contract ListOnZoraProposal is ZoraHelpers {
                 }
             }
             // Create a Zora auction for the NFT.
-            uint256 auctionId = _createZoraAuction(
+            _createZoraAuction(
                 data.listPrice,
                 data.timeout,
                 data.duration,
@@ -119,7 +112,6 @@ contract ListOnZoraProposal is ZoraHelpers {
                 abi.encode(
                     ZoraStep.ListedOnZora,
                     ZoraProgressData({
-                        auctionId: auctionId,
                         minExpiry: (block.timestamp + data.timeout).safeCastUint256ToUint40()
                     })
                 );
@@ -129,7 +121,7 @@ contract ListOnZoraProposal is ZoraHelpers {
             params.progressData,
             (ZoraStep, ZoraProgressData)
         );
-        _settleZoraAuction(pd.auctionId, pd.minExpiry, data.token, data.tokenId);
+        _settleZoraAuction(pd.minExpiry, data.token, data.tokenId);
         // Nothing left to do.
         return "";
     }
@@ -142,21 +134,14 @@ contract ListOnZoraProposal is ZoraHelpers {
         uint40 timeout,
         // How long the auction will run for once a bid has been placed.
         uint40 duration,
-        IERC721 token,
+        address token,
         uint256 tokenId
-    ) internal override returns (uint256 auctionId) {
-        token.approve(address(ZORA), tokenId);
-        auctionId = ZORA.createAuction(
-            tokenId,
-            token,
-            duration,
-            listPrice,
-            payable(address(0)),
-            0,
-            IERC20(address(0)) // Indicates ETH sale
-        );
+    ) internal virtual override {
+        IERC721(token).approve(address(ZORA.erc721TransferHelper()), tokenId);
+        ZORA.erc721TransferHelper().ZMM().setApprovalForModule(address(ZORA), true);
+
+        ZORA.createAuction(token, tokenId, duration, listPrice, address(this), 0);
         emit ZoraAuctionCreated(
-            auctionId,
             token,
             tokenId,
             listPrice,
@@ -167,40 +152,33 @@ contract ListOnZoraProposal is ZoraHelpers {
 
     // Either cancel or finalize a Zora auction.
     function _settleZoraAuction(
-        uint256 auctionId,
         uint40 minExpiry,
-        IERC721 token,
+        address token,
         uint256 tokenId
     ) internal override returns (ZoraAuctionStatus statusCode) {
-        // Getting the state of an auction is super expensive so it seems
-        // cheaper to just let `endAuction()` fail and react to the error.
-        try ZORA.endAuction(auctionId) {
-            // Check whether auction cancelled due to a failed transfer during
-            // settlement by seeing if we now possess the NFT.
-            if (token.safeOwnerOf(tokenId) == address(this)) {
-                emit ZoraAuctionFailed(auctionId);
-                return ZoraAuctionStatus.Cancelled;
-            }
-        } catch (bytes memory errData) {
-            bytes32 errHash = keccak256(errData);
-            if (errHash == AUCTION_HASNT_BEGUN_ERROR_HASH) {
-                // No bids placed.
-                // Cancel if we're past the timeout.
-                if (minExpiry > uint40(block.timestamp)) {
-                    revert ZoraListingNotExpired(auctionId, minExpiry);
-                }
-                ZORA.cancelAuction(auctionId);
-                emit ZoraAuctionExpired(auctionId, minExpiry);
-                return ZoraAuctionStatus.Expired;
-            } else if (errHash != AUCTION_DOESNT_EXIST_ERROR_HASH) {
-                // Otherwise, we should get an auction doesn't exist error,
-                // because someone else must have called `endAuction()`.
-                // If we didn't then something is wrong, so revert.
-                errData.rawRevert();
-            }
-            // Already ended by someone else. Nothing to do.
+        IReserveAuctionCoreEth.Auction memory auction = ZORA.auctionForNFT(token, tokenId);
+        if (auction.seller != address(this)) {
+            // Auction has already been settled
+            emit ZoraAuctionSold(token, tokenId);
+            return ZoraAuctionStatus.Sold;
         }
-        emit ZoraAuctionSold(auctionId);
-        return ZoraAuctionStatus.Sold;
+        if (auction.firstBidTime == 0) {
+            if (minExpiry > block.timestamp) {
+                revert ZoraListingNotExpired(token, tokenId, minExpiry);
+            }
+            // minExpiry passed with no bids
+            ZORA.cancelAuction(token, tokenId);
+            emit ZoraAuctionExpired(token, tokenId, minExpiry);
+            return ZoraAuctionStatus.Expired;
+        } else {
+            if (block.timestamp >= auction.duration + auction.firstBidTime) {
+                ZORA.settleAuction(token, tokenId);
+                emit ZoraAuctionSold(token, tokenId);
+                return ZoraAuctionStatus.Sold;
+            } else {
+                // Auction live
+                revert ZoraListingLive(token, tokenId, auction.firstBidTime + auction.duration);
+            }
+        }
     }
 }

--- a/contracts/proposals/ListOnZoraProposal.sol
+++ b/contracts/proposals/ListOnZoraProposal.sol
@@ -57,15 +57,18 @@ contract ListOnZoraProposal is ZoraHelpers {
     IReserveAuctionCoreEth public immutable ZORA;
     /// @notice Zora ERC721 tranfer helper for approvals
     BaseTransferHelper public immutable ZORA_TRANSFER_HELPER;
-    /// @notice Whether the Zora auction module has been approved (per party)
-    uint256 private constant _ZORA_PROPOSAL_STORAGE_SLOT =
-        uint256(keccak256("ListOnZoraProposal.Storage"));
-    struct ZoraProposalStorage {
-        bool zoraAuctionModuleApproved;
-    }
     // The `Globals` contract storing global configuration values. This contract
     // is immutable and it’s address will never change.
     IGlobals private immutable _GLOBALS;
+
+    /// @notice Use a constant, non-overlapping slot offset for the `ZoraProposalStorage` bucket
+    uint256 private constant _ZORA_PROPOSAL_STORAGE_SLOT =
+        uint256(keccak256("ListOnZoraProposal.Storage"));
+    /// @notice The storage struct for this contract
+    struct ZoraProposalStorage {
+        // Whether the Zora auction module has been approved (per party)
+        bool zoraAuctionModuleApproved;
+    }
 
     // Set immutables.
     constructor(IGlobals globals, IReserveAuctionCoreEth zora) {
@@ -196,7 +199,7 @@ contract ListOnZoraProposal is ZoraHelpers {
         }
     }
 
-    // Retrieve the explicit storage bucket for the ProposalExecutionEngine logic.
+    /// @notice Retrieve the explicit storage bucket for the `ZoraProposalStorage` struct.
     function _getZoraProposalStorage() private pure returns (ZoraProposalStorage storage stor) {
         uint256 slot = _ZORA_PROPOSAL_STORAGE_SLOT;
         assembly {

--- a/contracts/proposals/ListOnZoraProposal.sol
+++ b/contracts/proposals/ListOnZoraProposal.sol
@@ -64,8 +64,8 @@ contract ListOnZoraProposal is ZoraHelpers {
     IGlobals private immutable _GLOBALS;
 
     // Set immutables.
-    constructor(IGlobals globals, IReserveAuctionCoreEth zoraAuctionHouse) {
-        ZORA = zoraAuctionHouse;
+    constructor(IGlobals globals, IReserveAuctionCoreEth zora) {
+        ZORA = zora;
         ZORA_TRANSFER_HELPER = ZORA.erc721TransferHelper();
         _GLOBALS = globals;
     }

--- a/contracts/proposals/ProposalExecutionEngine.sol
+++ b/contracts/proposals/ProposalExecutionEngine.sol
@@ -98,7 +98,7 @@ contract ProposalExecutionEngine is
     // Set immutables.
     constructor(
         IGlobals globals,
-        IZoraAuctionHouse zoraAuctionHouse,
+        IReserveAuctionCoreEth zoraAuctionHouse,
         IFractionalV1VaultFactory fractionalVaultFactory
     )
         ListOnOpenseaAdvancedProposal(globals)

--- a/contracts/proposals/ProposalExecutionEngine.sol
+++ b/contracts/proposals/ProposalExecutionEngine.sol
@@ -98,13 +98,13 @@ contract ProposalExecutionEngine is
     // Set immutables.
     constructor(
         IGlobals globals,
-        IReserveAuctionCoreEth zoraAuctionHouse,
+        IReserveAuctionCoreEth zora,
         IFractionalV1VaultFactory fractionalVaultFactory
     )
         ListOnOpenseaAdvancedProposal(globals)
-        ListOnZoraProposal(globals, zoraAuctionHouse)
+        ListOnZoraProposal(globals, zora)
         FractionalizeProposal(fractionalVaultFactory)
-        ArbitraryCallsProposal(zoraAuctionHouse)
+        ArbitraryCallsProposal(zora)
     {
         _GLOBALS = globals;
     }

--- a/contracts/proposals/ZoraHelpers.sol
+++ b/contracts/proposals/ZoraHelpers.sol
@@ -8,8 +8,6 @@ import "../tokens/IERC721.sol";
 abstract contract ZoraHelpers {
     // ABI-encoded `progressData` passed into execute in the `ListedOnZora` step.
     struct ZoraProgressData {
-        // Auction ID.
-        uint256 auctionId;
         // The minimum timestamp when we can cancel the auction if no one bids.
         uint40 minExpiry;
     }
@@ -28,15 +26,14 @@ abstract contract ZoraHelpers {
         uint40 timeout,
         // How long the auction will run for once a bid has been placed.
         uint40 duration,
-        IERC721 token,
+        address token,
         uint256 tokenId
-    ) internal virtual returns (uint256 auctionId);
+    ) internal virtual;
 
     // Either cancel or finalize a Zora auction.
     function _settleZoraAuction(
-        uint256 auctionId,
         uint40 minExpiry,
-        IERC721 token,
+        address token,
         uint256 tokenId
     ) internal virtual returns (ZoraAuctionStatus statusCode);
 }

--- a/contracts/vendor/markets/IReserveAuctionCoreEth.sol
+++ b/contracts/vendor/markets/IReserveAuctionCoreEth.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+/// @title IReserveAuctionCoreEth
+/// @author kulkarohan
+/// @notice Interface for Reserve Auction Core ETH
+interface IReserveAuctionCoreEth {
+    /// @notice Creates an auction for a given NFT
+    /// @param _tokenContract The address of the ERC-721 token
+    /// @param _tokenId The id of the ERC-721 token
+    /// @param _duration The length of time the auction should run after the first bid
+    /// @param _reservePrice The minimum bid amount to start the auction
+    /// @param _sellerFundsRecipient The address to send funds to once the auction is complete
+    /// @param _startTime The time that users can begin placing bids
+    function createAuction(
+        address _tokenContract,
+        uint256 _tokenId,
+        uint256 _duration,
+        uint256 _reservePrice,
+        address _sellerFundsRecipient,
+        uint256 _startTime
+    ) external;
+
+    /// @notice Updates the auction reserve price for a given NFT
+    /// @param _tokenContract The address of the ERC-721 token
+    /// @param _tokenId The id of the ERC-721 token
+    /// @param _reservePrice The new reserve price
+    function setAuctionReservePrice(
+        address _tokenContract,
+        uint256 _tokenId,
+        uint256 _reservePrice
+    ) external;
+
+    /// @notice Cancels the auction for a given NFT
+    /// @param _tokenContract The address of the ERC-721 token
+    /// @param _tokenId The id of the ERC-721 token
+    function cancelAuction(address _tokenContract, uint256 _tokenId) external;
+
+    /// @notice Places a bid on the auction for a given NFT
+    /// @param _tokenContract The address of the ERC-721 token
+    /// @param _tokenId The id of the ERC-721 token
+    function createBid(address _tokenContract, uint256 _tokenId) external payable;
+
+    /// @notice Ends the auction for a given NFT
+    /// @param _tokenContract The address of the ERC-721 token
+    /// @param _tokenId The id of the ERC-721 token
+    function settleAuction(address _tokenContract, uint256 _tokenId) external;
+
+    function auctionForNFT(
+        address _tokenContract,
+        uint256 _tokenId
+    ) external view returns (Auction calldata);
+
+    function erc721TransferHelper() external pure returns (BaseTransferHelper);
+
+    /// @notice The metadata for a given auction
+    /// @param seller The address of the seller
+    /// @param reservePrice The reserve price to start the auction
+    /// @param sellerFundsRecipient The address where funds are sent after the auction
+    /// @param highestBid The highest bid of the auction
+    /// @param highestBidder The address of the highest bidder
+    /// @param duration The length of time that the auction runs after the first bid is placed
+    /// @param startTime The time that the first bid can be placed
+    /// @param firstBidTime The time that the first bid is placed
+    struct Auction {
+        address seller;
+        uint96 reservePrice;
+        address sellerFundsRecipient;
+        uint96 highestBid;
+        address highestBidder;
+        uint32 duration;
+        uint32 startTime;
+        uint32 firstBidTime;
+    }
+}
+
+interface ZoraModuleManager {
+    function setApprovalForModule(address, bool) external;
+}
+
+interface BaseTransferHelper {
+    function ZMM() external returns (ZoraModuleManager);
+}

--- a/deploy/Deploy.s.sol
+++ b/deploy/Deploy.s.sol
@@ -99,7 +99,9 @@ abstract contract Deploy {
         console.log("");
         console.log("### ProposalExecutionEngine");
         console.log("  Deploying - ProposalExecutionEngine");
-        IZoraAuctionHouse zoraAuctionHouse = IZoraAuctionHouse(deployConstants.zoraAuctionHouse);
+        IReserveAuctionCoreEth zoraAuctionHouse = IReserveAuctionCoreEth(
+            deployConstants.zoraAuctionHouse
+        );
         IFractionalV1VaultFactory fractionalVaultFactory = IFractionalV1VaultFactory(
             deployConstants.fractionalVaultFactory
         );

--- a/deploy/Deploy.s.sol
+++ b/deploy/Deploy.s.sol
@@ -99,8 +99,8 @@ abstract contract Deploy {
         console.log("");
         console.log("### ProposalExecutionEngine");
         console.log("  Deploying - ProposalExecutionEngine");
-        IReserveAuctionCoreEth zoraAuctionHouse = IReserveAuctionCoreEth(
-            deployConstants.zoraAuctionHouse
+        IReserveAuctionCoreEth zora = IReserveAuctionCoreEth(
+            deployConstants.zoraReserveAuctionCoreEth
         );
         IFractionalV1VaultFactory fractionalVaultFactory = IFractionalV1VaultFactory(
             deployConstants.fractionalVaultFactory
@@ -108,7 +108,7 @@ abstract contract Deploy {
         _trackDeployerGasBefore();
         proposalExecutionEngine = new ProposalExecutionEngine(
             globals,
-            zoraAuctionHouse,
+            zora,
             fractionalVaultFactory
         );
         _trackDeployerGasAfter();
@@ -350,7 +350,7 @@ abstract contract Deploy {
         if (address(deployConstants.deployedZoraMarketWrapper) == address(0)) {
             console.log("  Deploying - ZoraMarketWrapper");
             _trackDeployerGasBefore();
-            zoraMarketWrapper = new ZoraMarketWrapper(deployConstants.zoraAuctionHouse);
+            zoraMarketWrapper = new ZoraMarketWrapper(deployConstants.zoraReserveAuctionCoreEth); // TODO: This needs to be updated or removed
             _trackDeployerGasAfter();
             console.log("  Deployed - ZoraMarketWrapper", address(zoraMarketWrapper));
         } else {

--- a/deploy/LibDeployConstants.sol
+++ b/deploy/LibDeployConstants.sol
@@ -50,7 +50,7 @@ library LibDeployConstants {
             fractionalVaultFactory: 0x014850E83d9D0D1BB0c8624035F09626b967B81c,
             foundationMarket: 0xeB1bD095061bbDb1aD065524628812cae63e4222,
             nounsAuctionHouse: 0x7295e70f2B26986Ba108bD1Bf9E349a181F4a6Ea,
-            zoraAuctionHouse: 0x6a6Cdb103f1072E0aFeADAC9BeBD6E14B287Ca57,
+            zoraAuctionHouse: 0x2506D9F5A2b0E1A2619bCCe01CD3e7C289A13163,
             networkName: "goerli",
             deployedNounsMarketWrapper: 0x0000000000000000000000000000000000000000,
             deployedFoundationMarketWrapper: 0x0000000000000000000000000000000000000000,

--- a/deploy/LibDeployConstants.sol
+++ b/deploy/LibDeployConstants.sol
@@ -23,7 +23,7 @@ library LibDeployConstants {
         address fractionalVaultFactory;
         address foundationMarket;
         address nounsAuctionHouse;
-        address zoraAuctionHouse;
+        address zoraReserveAuctionCoreEth;
         string networkName;
         address deployedNounsMarketWrapper;
         address deployedFoundationMarketWrapper;
@@ -50,7 +50,7 @@ library LibDeployConstants {
             fractionalVaultFactory: 0x014850E83d9D0D1BB0c8624035F09626b967B81c,
             foundationMarket: 0xeB1bD095061bbDb1aD065524628812cae63e4222,
             nounsAuctionHouse: 0x7295e70f2B26986Ba108bD1Bf9E349a181F4a6Ea,
-            zoraAuctionHouse: 0x2506D9F5A2b0E1A2619bCCe01CD3e7C289A13163,
+            zoraReserveAuctionCoreEth: 0x2506D9F5A2b0E1A2619bCCe01CD3e7C289A13163,
             networkName: "goerli",
             deployedNounsMarketWrapper: 0x0000000000000000000000000000000000000000,
             deployedFoundationMarketWrapper: 0x0000000000000000000000000000000000000000,
@@ -80,7 +80,7 @@ library LibDeployConstants {
             fractionalVaultFactory: 0x85Aa7f78BdB2DE8F3e0c0010d99AD5853fFcfC63,
             foundationMarket: 0xcDA72070E455bb31C7690a170224Ce43623d0B6f,
             nounsAuctionHouse: 0x830BD73E4184ceF73443C15111a1DF14e495C706,
-            zoraAuctionHouse: 0xE468cE99444174Bd3bBBEd09209577d25D1ad673,
+            zoraReserveAuctionCoreEth: 0x5f7072E1fA7c01dfAc7Cf54289621AFAaD2184d0,
             networkName: "mainnet",
             deployedNounsMarketWrapper: 0x9319DAd8736D752C5c72DB229f8e1b280DC80ab1,
             deployedFoundationMarketWrapper: 0x96e5b0519983f2f984324b926e6d28C3A4Eb92A1,

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,7 @@ out = 'out'
 test = 'test'
 script = 'deploy'
 libs = ['lib']
+evm_version = 'shanghai'
 gas_reports = ['Proxy', 'Party', 'PartyGovernance', 'ProposalExecutionEngine', 'AuctionCrowdfund', 'BuyCrowdfund', 'CollectionBuyCrowdfund', 'Crowdfund', 'PartyFactory', 'CrowdfundFactory', 'TokenDistributor']
 remappings = [
   "forge-std/=lib/forge-std/src/",

--- a/test/party/PartyFactory.t.sol
+++ b/test/party/PartyFactory.t.sol
@@ -7,6 +7,7 @@ import "../../contracts/party/PartyFactory.sol";
 import "../../contracts/globals/Globals.sol";
 import "../TestUtils.sol";
 import "../../contracts/proposals/ProposalExecutionEngine.sol";
+import { MockZoraAuctionHouse } from "../proposals/MockZoraAuctionHouse.sol";
 
 contract PartyFactoryTest is Test, TestUtils {
     Globals globals = new Globals(address(this));
@@ -27,7 +28,7 @@ contract PartyFactoryTest is Test, TestUtils {
 
         eng = new ProposalExecutionEngine(
             globals,
-            IReserveAuctionCoreEth(_randomAddress()),
+            new MockZoraAuctionHouse(),
             IFractionalV1VaultFactory(_randomAddress())
         );
 

--- a/test/party/PartyFactory.t.sol
+++ b/test/party/PartyFactory.t.sol
@@ -27,7 +27,7 @@ contract PartyFactoryTest is Test, TestUtils {
 
         eng = new ProposalExecutionEngine(
             globals,
-            IZoraAuctionHouse(_randomAddress()),
+            IReserveAuctionCoreEth(_randomAddress()),
             IFractionalV1VaultFactory(_randomAddress())
         );
 

--- a/test/party/PartyFactory.t.sol
+++ b/test/party/PartyFactory.t.sol
@@ -7,7 +7,7 @@ import "../../contracts/party/PartyFactory.sol";
 import "../../contracts/globals/Globals.sol";
 import "../TestUtils.sol";
 import "../../contracts/proposals/ProposalExecutionEngine.sol";
-import { MockZoraAuctionHouse } from "../proposals/MockZoraAuctionHouse.sol";
+import { MockZoraReserveAuctionCoreEth } from "../proposals/MockZoraReserveAuctionCoreEth.sol";
 
 contract PartyFactoryTest is Test, TestUtils {
     Globals globals = new Globals(address(this));
@@ -28,7 +28,7 @@ contract PartyFactoryTest is Test, TestUtils {
 
         eng = new ProposalExecutionEngine(
             globals,
-            new MockZoraAuctionHouse(),
+            new MockZoraReserveAuctionCoreEth(),
             IFractionalV1VaultFactory(_randomAddress())
         );
 

--- a/test/proposals/ArbitraryCallsProposal.t.sol
+++ b/test/proposals/ArbitraryCallsProposal.t.sol
@@ -11,7 +11,7 @@ import "../TestUtils.sol";
 import "../DummyERC721.sol";
 
 contract TestableArbitraryCallsProposal is ArbitraryCallsProposal {
-    constructor(IZoraAuctionHouse zora) ArbitraryCallsProposal(zora) {}
+    constructor(IReserveAuctionCoreEth zora) ArbitraryCallsProposal(zora) {}
 
     function execute(
         IProposalExecutionEngine.ExecuteProposalParams calldata params,
@@ -50,7 +50,7 @@ contract ArbitraryCallTarget {
 }
 
 contract FakeZora {
-    function cancelAuction(uint256 auctionId) external {}
+    function cancelAuction(address _tokenContract, uint256 _tokenId) external {}
 }
 
 contract ArbitraryCallsProposalTest is
@@ -65,7 +65,7 @@ contract ArbitraryCallsProposalTest is
     ArbitraryCallTarget target = new ArbitraryCallTarget();
     FakeZora zora = new FakeZora();
     TestableArbitraryCallsProposal testContract =
-        new TestableArbitraryCallsProposal(IZoraAuctionHouse(address(zora)));
+        new TestableArbitraryCallsProposal(IReserveAuctionCoreEth(address(zora)));
     IERC721[] preciousTokens;
     uint256[] preciousTokenIds;
 
@@ -558,8 +558,8 @@ contract ArbitraryCallsProposalTest is
         (ArbitraryCallsProposal.ArbitraryCall[] memory calls, ) = _createSimpleCalls(2, false);
         calls[0].target = payable(address(zora));
         calls[0].data = abi.encodeCall(
-            IZoraAuctionHouse.cancelAuction,
-            (_randomUint256()) // params don't matter
+            IReserveAuctionCoreEth.cancelAuction,
+            (_randomAddress(), _randomUint256()) // params don't matter
         );
         IProposalExecutionEngine.ExecuteProposalParams memory prop = _createTestProposal(calls);
         vm.expectRevert(
@@ -576,8 +576,8 @@ contract ArbitraryCallsProposalTest is
         (ArbitraryCallsProposal.ArbitraryCall[] memory calls, ) = _createSimpleCalls(2, false);
         calls[1].target = payable(address(zora));
         calls[1].data = abi.encodeCall(
-            IZoraAuctionHouse.cancelAuction,
-            (_randomUint256()) // params don't matter
+            IReserveAuctionCoreEth.cancelAuction,
+            (_randomAddress(), _randomUint256()) // params don't matter
         );
         IProposalExecutionEngine.ExecuteProposalParams memory prop = _createTestProposal(calls);
         _expectEmit0();

--- a/test/proposals/ListOnZoraProposalForked.t.sol
+++ b/test/proposals/ListOnZoraProposalForked.t.sol
@@ -112,11 +112,21 @@ contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
             IProposalExecutionEngine.ExecuteProposalParams memory executeParams,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _createExecutionParams();
-        // _expectEmit3();
-        // emit AuctionCreated(
-        //     proposalData.token,
-        //     proposalData.tokenId,
-        // );
+        _expectEmit3();
+        emit AuctionCreated(
+            proposalData.token,
+            proposalData.tokenId,
+            IReserveAuctionCoreEth.Auction({
+                seller: address(proposal),
+                reservePrice: uint96(proposalData.listPrice),
+                sellerFundsRecipient: address(proposal),
+                highestBid: 0,
+                highestBidder: address(0),
+                duration: uint32(proposalData.duration),
+                startTime: 0,
+                firstBidTime: 0
+            })
+        );
         _expectEmit0();
         emit ZoraAuctionCreated(
             proposalData.token,
@@ -144,11 +154,21 @@ contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
         ) = _createExecutionParams();
         executeParams.progressData = proposal.executeListOnZora(executeParams);
         skip(proposalData.timeout);
-        // _expectEmit3();
-        // emit AuctionCanceled(
-        //     proposalData.token,
-        //     proposalData.tokenId
-        // );
+        _expectEmit3();
+        emit AuctionCanceled(
+            proposalData.token,
+            proposalData.tokenId,
+            IReserveAuctionCoreEth.Auction({
+                seller: address(proposal),
+                reservePrice: uint96(proposalData.listPrice),
+                sellerFundsRecipient: address(proposal),
+                highestBid: 0,
+                highestBidder: address(0),
+                duration: uint32(proposalData.duration),
+                startTime: 0,
+                firstBidTime: 0
+            })
+        );
         _expectEmit0();
         emit ZoraAuctionExpired(proposalData.token, proposalData.tokenId, block.timestamp);
         assertTrue(proposal.executeListOnZora(executeParams).length == 0);

--- a/test/proposals/ListOnZoraProposalForked.t.sol
+++ b/test/proposals/ListOnZoraProposalForked.t.sol
@@ -7,63 +7,50 @@ import "../TestUtils.sol";
 import "../DummyERC721.sol";
 import "./TestableListOnZoraProposal.sol";
 import "./ZoraTestUtils.sol";
+import { LibSafeCast } from "../../contracts/utils/LibSafeCast.sol";
+
+using LibSafeCast for uint256;
 
 contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
-    IZoraAuctionHouse ZORA = IZoraAuctionHouse(0xE468cE99444174Bd3bBBEd09209577d25D1ad673);
+    IReserveAuctionCoreEth ZORA =
+        IReserveAuctionCoreEth(0x5f7072E1fA7c01dfAc7Cf54289621AFAaD2184d0);
     Globals globals = new Globals(address(this));
     TestableListOnZoraProposal proposal = new TestableListOnZoraProposal(globals, ZORA);
     DummyERC721 nftToken = new DummyERC721();
     uint256 nftTokenId;
 
     event ZoraAuctionCreated(
-        uint256 auctionId,
-        IERC721 token,
+        address token,
         uint256 tokenId,
         uint256 startingPrice,
         uint40 duration,
         uint40 timeoutTime
     );
-    event ZoraAuctionExpired(uint256 auctionId, uint256 expiry);
-    event ZoraAuctionSold(uint256 auctionId);
-    event ZoraAuctionFailed(uint256 auctionId);
+    event ZoraAuctionExpired(address token, uint256 tokenid, uint256 expiry);
+    event ZoraAuctionSold(address token, uint256 tokenid);
 
     // Zora events
     event AuctionCreated(
-        uint256 indexed auctionId,
-        uint256 indexed tokenId,
         address indexed tokenContract,
-        uint256 duration,
-        uint256 reservePrice,
-        address tokenOwner,
-        address curator,
-        uint8 curatorFeePercentage,
-        address auctionCurrency
+        uint256 indexed tokenId,
+        IReserveAuctionCoreEth.Auction auction
     );
     event AuctionBid(
-        uint256 indexed auctionId,
-        uint256 indexed tokenId,
         address indexed tokenContract,
-        address sender,
-        uint256 value,
+        uint256 indexed tokenId,
         bool firstBid,
-        bool extended
+        bool extended,
+        IReserveAuctionCoreEth.Auction auction
     );
     event AuctionCanceled(
-        uint256 indexed auctionId,
-        uint256 indexed tokenId,
         address indexed tokenContract,
-        address tokenOwner
+        uint256 indexed tokenId,
+        IReserveAuctionCoreEth.Auction auction
     );
     event AuctionEnded(
-        uint256 indexed auctionId,
-        uint256 indexed tokenId,
         address indexed tokenContract,
-        address tokenOwner,
-        address curator,
-        address winner,
-        uint256 amount,
-        uint256 curatorFee,
-        address auctionCurrency
+        uint256 indexed tokenId,
+        IReserveAuctionCoreEth.Auction auction
     );
 
     constructor() ZoraTestUtils(ZORA) {
@@ -82,32 +69,42 @@ contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
             listPrice: _randomUint256() % 1e18,
             timeout: uint40(_randomRange(1 hours, 1 days)),
             duration: uint40(_randomRange(1 hours, 1 days)),
-            token: nftToken,
+            token: address(nftToken),
             tokenId: nftTokenId
         });
         executeParams.proposalData = abi.encode(proposalData);
     }
 
-    function _bidOnListing(uint256 auctionId, uint256 bid) private {
-        _bidOnListing(_randomAddress(), auctionId, bid);
+    function _bidOnListing(address tokenContract, uint256 tokenId, uint256 bid) private {
+        _bidOnListing(_randomAddress(), tokenContract, tokenId, bid);
     }
 
-    function _bidOnListing(address bidder, uint256 auctionId, uint256 bid) private {
-        IZoraAuctionHouse.Auction memory auction = ZORA.auctions(auctionId);
-        uint256 timeBuffer = ZORA.timeBuffer();
+    function _bidOnListing(
+        address bidder,
+        address tokenContract,
+        uint256 tokenId,
+        uint256 bid
+    ) private {
+        IReserveAuctionCoreEth.Auction memory auction = ZORA.auctionForNFT(tokenContract, tokenId);
+        uint256 timeBuffer = 15 minutes;
         vm.deal(bidder, bid);
         vm.prank(bidder);
+
+        // cache needed values
+        uint32 firstBidTime = auction.firstBidTime;
+        auction.highestBidder = bidder;
+        auction.highestBid = bid.safeCastUint256ToUint96();
+        auction.firstBidTime = uint32(block.timestamp);
+
         _expectEmit3();
         emit AuctionBid(
-            auctionId,
-            auction.tokenId,
-            address(auction.tokenContract),
-            bidder,
-            bid,
-            auction.firstBidTime == 0,
-            block.timestamp - auction.firstBidTime - auction.duration <= timeBuffer
+            tokenContract,
+            tokenId,
+            firstBidTime == 0,
+            auction.firstBidTime + auction.duration < block.timestamp + timeBuffer,
+            auction
         );
-        ZORA.createBid{ value: bid }(auctionId, bid);
+        ZORA.createBid{ value: bid }(tokenContract, tokenId);
     }
 
     function testForked_canCreateListing() external onlyForked {
@@ -115,22 +112,13 @@ contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
             IProposalExecutionEngine.ExecuteProposalParams memory executeParams,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _createExecutionParams();
-        uint256 auctionId = _getNextZoraAuctionId();
-        _expectEmit3();
-        emit AuctionCreated(
-            auctionId,
-            proposalData.tokenId,
-            address(proposalData.token),
-            proposalData.duration,
-            proposalData.listPrice,
-            address(proposal),
-            address(0),
-            0,
-            address(0)
-        );
+        // _expectEmit3();
+        // emit AuctionCreated(
+        //     proposalData.token,
+        //     proposalData.tokenId,
+        // );
         _expectEmit0();
         emit ZoraAuctionCreated(
-            auctionId,
             proposalData.token,
             proposalData.tokenId,
             proposalData.listPrice,
@@ -138,7 +126,6 @@ contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
             uint40(block.timestamp + proposalData.timeout)
         );
         assertTrue(proposal.executeListOnZora(executeParams).length > 0);
-        assertEq(proposalData.token.ownerOf(proposalData.tokenId), address(ZORA));
     }
 
     function testForked_canBidOnListing() external onlyForked {
@@ -146,9 +133,8 @@ contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
             IProposalExecutionEngine.ExecuteProposalParams memory executeParams,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _createExecutionParams();
-        uint256 auctionId = _getNextZoraAuctionId();
         proposal.executeListOnZora(executeParams);
-        _bidOnListing(auctionId, proposalData.listPrice);
+        _bidOnListing(proposalData.token, proposalData.tokenId, proposalData.listPrice);
     }
 
     function testForked_canCancelExpiredListing() external onlyForked {
@@ -156,18 +142,15 @@ contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
             IProposalExecutionEngine.ExecuteProposalParams memory executeParams,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _createExecutionParams();
-        uint256 auctionId = _getNextZoraAuctionId();
         executeParams.progressData = proposal.executeListOnZora(executeParams);
         skip(proposalData.timeout);
-        _expectEmit3();
-        emit AuctionCanceled(
-            auctionId,
-            proposalData.tokenId,
-            address(proposalData.token),
-            address(proposal)
-        );
+        // _expectEmit3();
+        // emit AuctionCanceled(
+        //     proposalData.token,
+        //     proposalData.tokenId
+        // );
         _expectEmit0();
-        emit ZoraAuctionExpired(auctionId, block.timestamp);
+        emit ZoraAuctionExpired(proposalData.token, proposalData.tokenId, block.timestamp);
         assertTrue(proposal.executeListOnZora(executeParams).length == 0);
     }
 
@@ -176,13 +159,13 @@ contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
             IProposalExecutionEngine.ExecuteProposalParams memory executeParams,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _createExecutionParams();
-        uint256 auctionId = _getNextZoraAuctionId();
         executeParams.progressData = proposal.executeListOnZora(executeParams);
         skip(proposalData.timeout - 1);
         vm.expectRevert(
             abi.encodeWithSelector(
                 ListOnZoraProposal.ZoraListingNotExpired.selector,
-                auctionId,
+                proposalData.token,
+                proposalData.tokenId,
                 block.timestamp + 1
             )
         );
@@ -194,10 +177,16 @@ contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
             IProposalExecutionEngine.ExecuteProposalParams memory executeParams,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _createExecutionParams();
-        uint256 auctionId = _getNextZoraAuctionId();
         executeParams.progressData = proposal.executeListOnZora(executeParams);
-        _bidOnListing(auctionId, proposalData.listPrice);
-        vm.expectRevert("Auction hasn't completed");
+        _bidOnListing(proposalData.token, proposalData.tokenId, proposalData.listPrice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ListOnZoraProposal.ZoraListingLive.selector,
+                proposalData.token,
+                proposalData.tokenId,
+                block.timestamp + proposalData.duration
+            )
+        );
         proposal.executeListOnZora(executeParams);
     }
 
@@ -206,12 +195,11 @@ contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
             IProposalExecutionEngine.ExecuteProposalParams memory executeParams,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _createExecutionParams();
-        uint256 auctionId = _getNextZoraAuctionId();
         executeParams.progressData = proposal.executeListOnZora(executeParams);
-        _bidOnListing(auctionId, proposalData.listPrice);
+        _bidOnListing(proposalData.token, proposalData.tokenId, proposalData.listPrice);
         skip(proposalData.duration);
         _expectEmit0();
-        emit ZoraAuctionSold(auctionId);
+        emit ZoraAuctionSold(proposalData.token, proposalData.tokenId);
         assertTrue(proposal.executeListOnZora(executeParams).length == 0);
         assertEq(address(proposal).balance, proposalData.listPrice);
     }
@@ -221,33 +209,14 @@ contract ListOnZoraProposalForkedTest is ZoraTestUtils, TestUtils {
             IProposalExecutionEngine.ExecuteProposalParams memory executeParams,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _createExecutionParams();
-        uint256 auctionId = _getNextZoraAuctionId();
         executeParams.progressData = proposal.executeListOnZora(executeParams);
-        _bidOnListing(auctionId, proposalData.listPrice);
+        _bidOnListing(proposalData.token, proposalData.tokenId, proposalData.listPrice);
         skip(proposalData.duration);
-        ZORA.endAuction(auctionId);
+        ZORA.settleAuction(proposalData.token, proposalData.tokenId);
         _expectEmit0();
-        emit ZoraAuctionSold(auctionId);
+        emit ZoraAuctionSold(proposalData.token, proposalData.tokenId);
         assertTrue(proposal.executeListOnZora(executeParams).length == 0);
         assertEq(address(proposal).balance, proposalData.listPrice);
-    }
-
-    function testForked_canSettleIfAuctionFails() external onlyForked {
-        (
-            IProposalExecutionEngine.ExecuteProposalParams memory executeParams,
-            ListOnZoraProposal.ZoraProposalData memory proposalData
-        ) = _createExecutionParams();
-        uint256 auctionId = _getNextZoraAuctionId();
-        executeParams.progressData = proposal.executeListOnZora(executeParams);
-        // Use a bidder that reverts when it receives the NFT, failing the entire
-        // auction.
-        _bidOnListing(address(new BadBidder()), auctionId, proposalData.listPrice);
-        skip(proposalData.duration);
-        _expectEmit0();
-        emit ZoraAuctionFailed(auctionId);
-        assertTrue(proposal.executeListOnZora(executeParams).length == 0);
-        assertEq(address(proposal).balance, 0);
-        assertEq(proposalData.token.ownerOf(proposalData.tokenId), address(proposal));
     }
 }
 

--- a/test/proposals/ListOnZoraProposalUnit.t.sol
+++ b/test/proposals/ListOnZoraProposalUnit.t.sol
@@ -12,10 +12,7 @@ contract ListOnZoraProposalUnitTest is Test, TestUtils {
     MockZoraAuctionHouse zora = new MockZoraAuctionHouse();
     Globals globals = new Globals(address(this));
     UnitTestableListOnZoraProposal impl =
-        new UnitTestableListOnZoraProposal(
-            IGlobals(address(globals)),
-            IReserveAuctionCoreEth(zora)
-        );
+        new UnitTestableListOnZoraProposal(IGlobals(address(globals)), zora);
     DummyERC721 token = new DummyERC721();
     uint256 tokenId = token.mint(address(impl));
 

--- a/test/proposals/ListOnZoraProposalUnit.t.sol
+++ b/test/proposals/ListOnZoraProposalUnit.t.sol
@@ -11,14 +11,16 @@ import "../DummyERC721.sol";
 contract ListOnZoraProposalUnitTest is Test, TestUtils {
     MockZoraAuctionHouse zora = new MockZoraAuctionHouse();
     Globals globals = new Globals(address(this));
-    TestableListOnZoraProposal impl =
-        new TestableListOnZoraProposal(IGlobals(address(globals)), IZoraAuctionHouse(zora));
+    UnitTestableListOnZoraProposal impl =
+        new UnitTestableListOnZoraProposal(
+            IGlobals(address(globals)),
+            IReserveAuctionCoreEth(zora)
+        );
     DummyERC721 token = new DummyERC721();
     uint256 tokenId = token.mint(address(impl));
 
     event ZoraAuctionCreated(
-        uint256 auctionId,
-        IERC721 token,
+        address token,
         uint256 tokenId,
         uint256 startingPrice,
         uint40 duration,
@@ -48,7 +50,7 @@ contract ListOnZoraProposalUnitTest is Test, TestUtils {
             listPrice: listPrice,
             timeout: timeout,
             duration: duration,
-            token: token,
+            token: address(token),
             tokenId: tokenId
         });
 
@@ -88,8 +90,7 @@ contract ListOnZoraProposalUnitTest is Test, TestUtils {
         params.proposalData = abi.encode(data);
         _expectEmit0();
         emit ZoraAuctionCreated(
-            zora.lastAuctionId() + 1,
-            data.token,
+            address(data.token),
             data.tokenId,
             data.listPrice,
             minDuration,
@@ -105,8 +106,7 @@ contract ListOnZoraProposalUnitTest is Test, TestUtils {
         params.proposalData = abi.encode(data);
         _expectEmit0();
         emit ZoraAuctionCreated(
-            zora.lastAuctionId() + 1,
-            data.token,
+            address(data.token),
             data.tokenId,
             data.listPrice,
             maxDuration,
@@ -127,8 +127,7 @@ contract ListOnZoraProposalUnitTest is Test, TestUtils {
         params.proposalData = abi.encode(data);
         _expectEmit0();
         emit ZoraAuctionCreated(
-            zora.lastAuctionId() + 1,
-            data.token,
+            address(data.token),
             data.tokenId,
             data.listPrice,
             data.duration,

--- a/test/proposals/ListOnZoraProposalUnit.t.sol
+++ b/test/proposals/ListOnZoraProposalUnit.t.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8;
 import "contracts/proposals/ListOnZoraProposal.sol";
 import "contracts/globals/Globals.sol";
 import "../TestUtils.sol";
-import "./MockZoraAuctionHouse.sol";
+import "./MockZoraReserveAuctionCoreEth.sol";
 import "./TestableListOnZoraProposal.sol";
 import "../DummyERC721.sol";
 
 contract ListOnZoraProposalUnitTest is Test, TestUtils {
-    MockZoraAuctionHouse zora = new MockZoraAuctionHouse();
+    MockZoraReserveAuctionCoreEth zora = new MockZoraReserveAuctionCoreEth();
     Globals globals = new Globals(address(this));
     UnitTestableListOnZoraProposal impl =
         new UnitTestableListOnZoraProposal(IGlobals(address(globals)), zora);

--- a/test/proposals/MockZoraAuctionHouse.sol
+++ b/test/proposals/MockZoraAuctionHouse.sol
@@ -5,41 +5,42 @@ import "forge-std/Test.sol";
 
 import "../../contracts/tokens/IERC20.sol";
 import "../../contracts/tokens/IERC721.sol";
-import "../../contracts/vendor/markets/IZoraAuctionHouse.sol";
+import "../../contracts/vendor/markets/IReserveAuctionCoreEth.sol";
 
-contract MockZoraAuctionHouse is IZoraAuctionHouse {
+contract MockZoraAuctionHouse is IReserveAuctionCoreEth {
     uint256 public lastAuctionId = 8000;
     uint256 public timeBuffer = 15 minutes;
 
     function createAuction(
-        uint256,
-        IERC721,
-        uint256,
-        uint256,
-        address payable,
-        uint8,
-        IERC20
-    ) external returns (uint256 auctionId) {
-        auctionId = ++lastAuctionId;
-    }
+        address _tokenContract,
+        uint256 _tokenId,
+        uint256 _duration,
+        uint256 _reservePrice,
+        address _sellerFundsRecipient,
+        uint256 _startTime
+    ) external override {}
 
-    function createBid(uint256, uint256) external payable {
+    function createBid(address, uint256) external payable override {
         revert("no implementado");
     }
 
-    function endAuction(uint256) external pure {
+    function setAuctionReservePrice(address, uint256, uint256) external pure override {
+        revert("no implementation");
+    }
+
+    function cancelAuction(address, uint256) external pure override {
         revert("no implementado");
     }
 
-    function cancelAuction(uint256) external pure {
+    function auctionForNFT(address, uint256) external pure override returns (Auction calldata) {
         revert("no implementado");
     }
 
-    function auctions(uint256) external pure returns (Auction memory) {
-        revert("no implementado");
+    function settleAuction(address, uint256) external pure override {
+        revert("no implementation");
     }
 
-    function minBidIncrementPercentage() external pure returns (uint8) {
-        revert("no implementado");
+    function erc721TransferHelper() external pure override returns (BaseTransferHelper) {
+        revert("no implementation");
     }
 }

--- a/test/proposals/MockZoraAuctionHouse.sol
+++ b/test/proposals/MockZoraAuctionHouse.sol
@@ -41,6 +41,6 @@ contract MockZoraAuctionHouse is IReserveAuctionCoreEth {
     }
 
     function erc721TransferHelper() external pure override returns (BaseTransferHelper) {
-        revert("no implementation");
+        return BaseTransferHelper(address(0));
     }
 }

--- a/test/proposals/MockZoraReserveAuctionCoreEth.sol
+++ b/test/proposals/MockZoraReserveAuctionCoreEth.sol
@@ -7,7 +7,7 @@ import "../../contracts/tokens/IERC20.sol";
 import "../../contracts/tokens/IERC721.sol";
 import "../../contracts/vendor/markets/IReserveAuctionCoreEth.sol";
 
-contract MockZoraAuctionHouse is IReserveAuctionCoreEth {
+contract MockZoraReserveAuctionCoreEth is IReserveAuctionCoreEth {
     uint256 public lastAuctionId = 8000;
     uint256 public timeBuffer = 15 minutes;
 

--- a/test/proposals/ProposalExecutionEngine.t.sol
+++ b/test/proposals/ProposalExecutionEngine.t.sol
@@ -11,6 +11,7 @@ import "../TestUtils.sol";
 
 import "./TestableProposalExecutionEngine.sol";
 import "./DummyProposalEngineImpl.sol";
+import { MockZoraAuctionHouse } from "./MockZoraAuctionHouse.sol";
 
 contract ProposalExecutionEngineTest is Test, TestUtils {
     // From TestableProposalExecutionEngine
@@ -36,7 +37,7 @@ contract ProposalExecutionEngineTest is Test, TestUtils {
             globals,
             IOpenseaExchange(_randomAddress()),
             IOpenseaConduitController(_randomAddress()),
-            IReserveAuctionCoreEth(_randomAddress()),
+            IReserveAuctionCoreEth(new MockZoraAuctionHouse()),
             IFractionalV1VaultFactory(_randomAddress())
         );
     }

--- a/test/proposals/ProposalExecutionEngine.t.sol
+++ b/test/proposals/ProposalExecutionEngine.t.sol
@@ -11,7 +11,7 @@ import "../TestUtils.sol";
 
 import "./TestableProposalExecutionEngine.sol";
 import "./DummyProposalEngineImpl.sol";
-import { MockZoraAuctionHouse } from "./MockZoraAuctionHouse.sol";
+import { MockZoraReserveAuctionCoreEth } from "./MockZoraReserveAuctionCoreEth.sol";
 
 contract ProposalExecutionEngineTest is Test, TestUtils {
     // From TestableProposalExecutionEngine
@@ -37,7 +37,7 @@ contract ProposalExecutionEngineTest is Test, TestUtils {
             globals,
             IOpenseaExchange(_randomAddress()),
             IOpenseaConduitController(_randomAddress()),
-            IReserveAuctionCoreEth(new MockZoraAuctionHouse()),
+            IReserveAuctionCoreEth(new MockZoraReserveAuctionCoreEth()),
             IFractionalV1VaultFactory(_randomAddress())
         );
     }

--- a/test/proposals/ProposalExecutionEngine.t.sol
+++ b/test/proposals/ProposalExecutionEngine.t.sol
@@ -36,7 +36,7 @@ contract ProposalExecutionEngineTest is Test, TestUtils {
             globals,
             IOpenseaExchange(_randomAddress()),
             IOpenseaConduitController(_randomAddress()),
-            IZoraAuctionHouse(_randomAddress()),
+            IReserveAuctionCoreEth(_randomAddress()),
             IFractionalV1VaultFactory(_randomAddress())
         );
     }

--- a/test/proposals/TestableListOnOpenseaProposal.sol
+++ b/test/proposals/TestableListOnOpenseaProposal.sol
@@ -18,7 +18,7 @@ contract TestableListOnOpenseaProposal is
 {
     constructor(
         IGlobals globals,
-        IZoraAuctionHouse zora
+        IReserveAuctionCoreEth zora
     ) ListOnOpenseaAdvancedProposal(globals) ListOnZoraProposal(globals, zora) {}
 
     receive() external payable {}

--- a/test/proposals/TestableListOnZoraProposal.sol
+++ b/test/proposals/TestableListOnZoraProposal.sol
@@ -10,7 +10,7 @@ import "../../contracts/tokens/ERC721Receiver.sol";
 contract TestableListOnZoraProposal is ListOnZoraProposal, ERC721Receiver {
     constructor(
         IGlobals globals,
-        IZoraAuctionHouse zoraAuctionHouse
+        IReserveAuctionCoreEth zoraAuctionHouse
     ) ListOnZoraProposal(globals, zoraAuctionHouse) {}
 
     function executeListOnZora(
@@ -20,4 +20,32 @@ contract TestableListOnZoraProposal is ListOnZoraProposal, ERC721Receiver {
     }
 
     receive() external payable {}
+}
+
+contract UnitTestableListOnZoraProposal is TestableListOnZoraProposal {
+    constructor(
+        IGlobals globals,
+        IReserveAuctionCoreEth zoraAuctionHouse
+    ) TestableListOnZoraProposal(globals, zoraAuctionHouse) {}
+
+    // Transfer and create a Zora auction for the `token` + `tokenId`.
+    function _createZoraAuction(
+        // The minimum bid.
+        uint256 listPrice,
+        // How long the auction must wait for the first bid.
+        uint40 timeout,
+        // How long the auction will run for once a bid has been placed.
+        uint40 duration,
+        address token,
+        uint256 tokenId
+    ) internal override {
+        ZORA.createAuction(token, tokenId, duration, listPrice, address(this), 0);
+        emit ZoraAuctionCreated(
+            token,
+            tokenId,
+            listPrice,
+            duration,
+            uint40(block.timestamp + timeout)
+        );
+    }
 }

--- a/test/proposals/TestableProposalExecutionEngine.sol
+++ b/test/proposals/TestableProposalExecutionEngine.sol
@@ -18,7 +18,7 @@ contract TestableProposalExecutionEngine is ProposalExecutionEngine {
         IGlobals globals,
         IOpenseaExchange seaport,
         IOpenseaConduitController seaportConduitController,
-        IZoraAuctionHouse zora,
+        IReserveAuctionCoreEth zora,
         IFractionalV1VaultFactory fractionalVaultFactory
     ) ProposalExecutionEngine(globals, zora, fractionalVaultFactory) {}
 

--- a/test/proposals/ZoraTestUtils.sol
+++ b/test/proposals/ZoraTestUtils.sol
@@ -3,21 +3,22 @@ pragma solidity ^0.8;
 
 import "forge-std/Test.sol";
 
-import "../../contracts/vendor/markets/IZoraAuctionHouse.sol";
+import "../../contracts/vendor/markets/IReserveAuctionCoreEth.sol";
 
 contract ZoraTestUtils is Test {
-    IZoraAuctionHouse private immutable _ZORA;
+    IReserveAuctionCoreEth private immutable _ZORA;
 
-    constructor(IZoraAuctionHouse zora) {
+    constructor(IReserveAuctionCoreEth zora) {
         _ZORA = zora;
     }
 
-    function _bidOnZoraListing(uint256 auctionId, address bidder, uint256 bidPrice) internal {
+    function _bidOnZoraListing(
+        address tokenContract,
+        uint256 tokenId,
+        address bidder,
+        uint256 bidPrice
+    ) internal {
         hoax(bidder, bidPrice);
-        _ZORA.createBid{ value: bidPrice }(auctionId, bidPrice);
-    }
-
-    function _getNextZoraAuctionId() internal view returns (uint256 auctionId) {
-        return uint256(vm.load(address(_ZORA), bytes32(uint256(5))));
+        _ZORA.createBid{ value: bidPrice }(tokenContract, tokenId);
     }
 }


### PR DESCRIPTION
Link T-2846

## Motivation

The Zora v2 auction house has existing security vulnerabilities and is non-upgradable. Parties need a way to list their NFTs for english auction securely.

## Solution

We migrate party protocol to use the new Zora v3 contracts which have fixed this vulnerability.