### PR TITLE
Refactor: Change Zora auction start time to`block.timestamp`

### DIFF
--- a/contracts/proposals/ListOnZoraProposal.sol
+++ b/contracts/proposals/ListOnZoraProposal.sol
@@ -151,7 +151,7 @@ contract ListOnZoraProposal is ZoraHelpers {
         }
         IERC721(token).approve(address(ZORA_TRANSFER_HELPER), tokenId);
 
-        ZORA.createAuction(token, tokenId, duration, listPrice, address(this), 0);
+        ZORA.createAuction(token, tokenId, duration, listPrice, address(this), block.timestamp);
         emit ZoraAuctionCreated(
             token,
             tokenId,

--- a/test/proposals/ListOnZoraProposalForked.t.sol
+++ b/test/proposals/ListOnZoraProposalForked.t.sol
@@ -123,7 +123,7 @@ contract ListOnZoraProposalForkedTest is TestUtils {
                 highestBid: 0,
                 highestBidder: address(0),
                 duration: uint32(proposalData.duration),
-                startTime: 0,
+                startTime: uint32(block.timestamp),
                 firstBidTime: 0
             })
         );
@@ -152,6 +152,7 @@ contract ListOnZoraProposalForkedTest is TestUtils {
             IProposalExecutionEngine.ExecuteProposalParams memory executeParams,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _createExecutionParams();
+        uint32 auctionStartTime = uint32(block.timestamp);
         executeParams.progressData = proposal.executeListOnZora(executeParams);
         skip(proposalData.timeout);
         _expectEmit3();
@@ -165,7 +166,7 @@ contract ListOnZoraProposalForkedTest is TestUtils {
                 highestBid: 0,
                 highestBidder: address(0),
                 duration: uint32(proposalData.duration),
-                startTime: 0,
+                startTime: auctionStartTime,
                 firstBidTime: 0
             })
         );


### PR DESCRIPTION
For ease of distinction between different auctions for the same NFT, we set the auction start time to `block.timestamp`.