### PR TITLE
feat: ERC1271 signatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: Tests
 
-on: push
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  push:
 
 env:
   FORK_URL: ${{ secrets.FORK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
       - dev
   push:
+    branches:
+      - main
+      - dev
 
 env:
   FORK_URL: ${{ secrets.FORK_URL }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,4 @@ coverage:
     patch:
       default:
         target: 90%
+        if_ci_failed: error

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,6 @@ ignore:
   - "deploy"
 
 coverage:
-  range: 70..90
   status:
     patch:
       default:

--- a/contracts/globals/LibGlobals.sol
+++ b/contracts/globals/LibGlobals.sol
@@ -42,4 +42,5 @@ library LibGlobals {
     // uint256 internal constant GLOBAL_RERAISE_ETH_CF_IMPL = 29;
     uint256 internal constant GLOBAL_SEAPORT = 30;
     uint256 internal constant GLOBAL_CONDUIT_CONTROLLER = 31;
+    uint256 internal constant GLOBAL_OFF_CHAIN_SIGNATURE_VALIDATOR = 32;
 }

--- a/contracts/proposals/ProposalExecutionEngine.sol
+++ b/contracts/proposals/ProposalExecutionEngine.sol
@@ -228,7 +228,7 @@ contract ProposalExecutionEngine is
         if (address(validator) != address(0)) {
             return validator.isValidSignature(hash, signature);
         }
-        if (msg.sender == address(0)) {
+        if (tx.origin == address(0)) {
             validator = getSignatureValidatorForHash(0);
             if (address(validator) == address(0)) {
                 // Use global off-chain signature validator

--- a/contracts/proposals/SetSignatureValidatorProposal.sol
+++ b/contracts/proposals/SetSignatureValidatorProposal.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+import { IERC1271 } from "openzeppelin/contracts/interfaces/IERC1271.sol";
+import { ProposalStorage } from "./ProposalStorage.sol";
+import { IProposalExecutionEngine } from "./IProposalExecutionEngine.sol";
+
+abstract contract SetSignatureValidatorProposal is ProposalStorage {
+    struct SetSignatureValidatorProposalStorage {
+        /// @notice Mapping from signature hash to signature validator for validating ERC1271 signatures.
+        mapping(bytes32 => IERC1271) signatureValidators;
+    }
+    /// @notice Use a constant, non-overlapping slot offset for the `ZoraProposalStorage` bucket
+    uint256 private constant _SET_SIGNATURE_VALIDATOR_PROPOSAL_STORAGE_SLOT =
+        uint256(keccak256("SetSignatureValidatorProposal.Storage"));
+    struct SetSignatureValidatorProposalData {
+        bytes32 signatureHash;
+        IERC1271 signatureValidator;
+    }
+
+    /// @notice Execute a `SetSignatureValidatorProposal` which sets the validator for a given hash.
+    function _executeSetSignatureValidator(
+        IProposalExecutionEngine.ExecuteProposalParams memory params
+    ) internal returns (bytes memory nextProgressData) {
+        SetSignatureValidatorProposalData memory data = abi.decode(
+            params.proposalData,
+            (SetSignatureValidatorProposalData)
+        );
+        _getSetSignatureValidatorProposalStorage().signatureValidators[data.signatureHash] = data
+            .signatureValidator;
+        nextProgressData = "";
+    }
+
+    /// @notice Retrieve the explicit storage bucket for the `SetSignatureValidatorProposal` struct.
+    function _getSetSignatureValidatorProposalStorage()
+        internal
+        pure
+        returns (SetSignatureValidatorProposalStorage storage stor)
+    {
+        uint256 slot = _SET_SIGNATURE_VALIDATOR_PROPOSAL_STORAGE_SLOT;
+        assembly {
+            stor.slot := slot
+        }
+    }
+}

--- a/contracts/proposals/SetSignatureValidatorProposal.sol
+++ b/contracts/proposals/SetSignatureValidatorProposal.sol
@@ -13,10 +13,17 @@ abstract contract SetSignatureValidatorProposal is ProposalStorage {
     /// @notice Use a constant, non-overlapping slot offset for the `ZoraProposalStorage` bucket
     uint256 private constant _SET_SIGNATURE_VALIDATOR_PROPOSAL_STORAGE_SLOT =
         uint256(keccak256("SetSignatureValidatorProposal.Storage"));
+
+    /// @notice Struct containing data required for this proposal type
     struct SetSignatureValidatorProposalData {
         bytes32 signatureHash;
         IERC1271 signatureValidator;
     }
+
+    /// @notice Emmitted when the signature validator for a hash is updated
+    /// @param hash The hash to update the signature validator for
+    /// @param signatureValidator The new signature validator for the hash
+    event SignatureValidatorSet(bytes32 indexed hash, IERC1271 indexed signatureValidator);
 
     /// @notice Execute a `SetSignatureValidatorProposal` which sets the validator for a given hash.
     function _executeSetSignatureValidator(
@@ -29,11 +36,17 @@ abstract contract SetSignatureValidatorProposal is ProposalStorage {
         _getSetSignatureValidatorProposalStorage().signatureValidators[data.signatureHash] = data
             .signatureValidator;
         nextProgressData = "";
+
+        emit SignatureValidatorSet(data.signatureHash, data.signatureValidator);
+    }
+
+    function getSignatureValidatorForHash(bytes32 hash) public view returns (IERC1271) {
+        return _getSetSignatureValidatorProposalStorage().signatureValidators[hash];
     }
 
     /// @notice Retrieve the explicit storage bucket for the `SetSignatureValidatorProposal` struct.
     function _getSetSignatureValidatorProposalStorage()
-        internal
+        private
         pure
         returns (SetSignatureValidatorProposalStorage storage stor)
     {

--- a/contracts/proposals/SetSignatureValidatorProposal.sol
+++ b/contracts/proposals/SetSignatureValidatorProposal.sol
@@ -2,10 +2,9 @@
 pragma solidity 0.8.20;
 
 import { IERC1271 } from "openzeppelin/contracts/interfaces/IERC1271.sol";
-import { ProposalStorage } from "./ProposalStorage.sol";
 import { IProposalExecutionEngine } from "./IProposalExecutionEngine.sol";
 
-abstract contract SetSignatureValidatorProposal is ProposalStorage {
+abstract contract SetSignatureValidatorProposal {
     struct SetSignatureValidatorProposalStorage {
         /// @notice Mapping from signature hash to signature validator for validating ERC1271 signatures.
         mapping(bytes32 => IERC1271) signatureValidators;

--- a/contracts/signature-validators/OffChainSignatureValidator.sol
+++ b/contracts/signature-validators/OffChainSignatureValidator.sol
@@ -5,18 +5,20 @@ import { IERC1271 } from "openzeppelin/contracts/interfaces/IERC1271.sol";
 import { Strings } from "openzeppelin/contracts/utils/Strings.sol";
 import { Party } from "../party/Party.sol";
 
-/// @notice Contract that by default validates off-chain signature for parties
+/// @notice Contract that by default validates off-chain signatures for parties
 contract OffChainSignatureValidator is IERC1271 {
     error NotMemberOfParty();
     error InsufficientVotingPower();
     error MessageHashMismatch();
 
+    /// @notice Event emmitted when signing threshold updated
     event SigningThresholdBpsSet(
         Party indexed party,
         uint96 oldThresholdBps,
         uint96 newThresholdBps
     );
 
+    /// @notice Mapping of party to signing threshold BPS
     mapping(Party party => uint96 thresholdBps) public signingThersholdBps;
 
     /// @notice Validate an off-chain signature
@@ -79,7 +81,7 @@ contract OffChainSignatureValidator is IERC1271 {
 
     /// @notice Set the signing threshold BPS for the party to validate off-chain signatures
     /// @param thresholdBps The new threshold BPS
-    function setSigningThersholdBps(uint96 thresholdBps) external {
+    function setSigningThresholdBps(uint96 thresholdBps) external {
         Party party = Party(payable(msg.sender));
         emit SigningThresholdBpsSet(party, signingThersholdBps[party], thresholdBps);
         signingThersholdBps[party] = thresholdBps;

--- a/contracts/signature-validators/OffChainSignatureValidator.sol
+++ b/contracts/signature-validators/OffChainSignatureValidator.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+import { IERC1271 } from "openzeppelin/contracts/interfaces/IERC1271.sol";
+import { Strings } from "openzeppelin/contracts/utils/Strings.sol";
+import { Party } from "../party/Party.sol";
+
+/// @notice Contract that by default validates off-chain signature for parties
+contract OffChainSignatureValidator is IERC1271 {
+    error NotMemberOfParty();
+    error InsufficientVotingPower();
+    error MessageHashMismatch();
+
+    event SigningThresholdBipsSet(Party party, uint96 oldThresholdBips, uint96 newThresholdBips);
+
+    mapping(Party party => uint96 thresholdBips) public signingThersholdBips;
+
+    /// @notice Validate an off-chain signature
+    /// @dev This function requires `signature` to be a valid EOA signature from a member in the
+    /// party with sufficient voting power. The raw message must be abi encoded and appended to
+    /// the end of the signature. EIP-712 typed signatures are not supported.
+    function isValidSignature(bytes32 hash, bytes memory signature) external view returns (bytes4) {
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        assembly {
+            // First word of signature after size contains r
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            // v is one byte which starts after s. type is uint8 so extra data will be ignored
+            v := mload(add(signature, 0x41))
+        }
+
+        bytes memory rawMessageData;
+        assembly {
+            // Raw message data begins after v. Overwriting part of s and v with size of `rawMessageData`
+            rawMessageData := add(signature, 0x41)
+            mstore(rawMessageData, sub(mload(signature), 0x41))
+        }
+        bytes memory message = abi.encodePacked(abi.decode(rawMessageData, (string)));
+
+        // Recreate the message pre-hash from the raw data
+        bytes memory encodedPacket = abi.encodePacked(
+            "\x19Ethereum Signed Message:\n",
+            Strings.toString(message.length),
+            message
+        );
+        if (keccak256(encodedPacket) != hash) {
+            revert MessageHashMismatch();
+        }
+
+        Party party = Party(payable(msg.sender));
+        address signer = ecrecover(hash, v, r, s);
+        uint96 signerVotingPowerBips = party.getVotingPowerAt(signer, uint40(block.timestamp)) *
+            10000;
+
+        if (signerVotingPowerBips == 0 && party.balanceOf(signer) == 0) {
+            // Must own a party card or be delegatated voting power
+            revert NotMemberOfParty();
+        }
+
+        uint96 totalVotingPower = party.getGovernanceValues().totalVotingPower;
+        uint96 thresholdBips = signingThersholdBips[party];
+
+        // Either threshold is 0 or signer votes above threshold
+        if (
+            thresholdBips == 0 ||
+            (signerVotingPowerBips > totalVotingPower &&
+                signerVotingPowerBips / totalVotingPower >= thresholdBips)
+        ) {
+            return IERC1271.isValidSignature.selector;
+        }
+
+        revert InsufficientVotingPower();
+    }
+
+    /// @notice Set the signing threshold BIPS for the party to validate off-chain signatures
+    /// @param thresholdBips The new threshold BIPS
+    function setSigningThersholdBips(uint96 thresholdBips) external {
+        Party party = Party(payable(msg.sender));
+        emit SigningThresholdBipsSet(party, signingThersholdBips[party], thresholdBips);
+        signingThersholdBips[party] = thresholdBips;
+    }
+}

--- a/contracts/signature-validators/OffChainSignatureValidator.sol
+++ b/contracts/signature-validators/OffChainSignatureValidator.sol
@@ -11,13 +11,13 @@ contract OffChainSignatureValidator is IERC1271 {
     error InsufficientVotingPower();
     error MessageHashMismatch();
 
-    event SigningThresholdBipsSet(
+    event SigningThresholdBpsSet(
         Party indexed party,
-        uint96 oldThresholdBips,
-        uint96 newThresholdBips
+        uint96 oldThresholdBps,
+        uint96 newThresholdBps
     );
 
-    mapping(Party party => uint96 thresholdBips) public signingThersholdBips;
+    mapping(Party party => uint96 thresholdBps) public signingThersholdBps;
 
     /// @notice Validate an off-chain signature
     /// @dev This function requires `signature` to be a valid EOA signature from a member in the
@@ -54,22 +54,22 @@ contract OffChainSignatureValidator is IERC1271 {
 
         Party party = Party(payable(msg.sender));
         address signer = ecrecover(hash, v, r, s);
-        uint96 signerVotingPowerBips = party.getVotingPowerAt(signer, uint40(block.timestamp)) *
+        uint96 signerVotingPowerBps = party.getVotingPowerAt(signer, uint40(block.timestamp)) *
             10000;
 
-        if (signerVotingPowerBips == 0 && party.balanceOf(signer) == 0) {
+        if (signerVotingPowerBps == 0 && party.balanceOf(signer) == 0) {
             // Must own a party card or be delegatated voting power
             revert NotMemberOfParty();
         }
 
         uint96 totalVotingPower = party.getGovernanceValues().totalVotingPower;
-        uint96 thresholdBips = signingThersholdBips[party];
+        uint96 thresholdBps = signingThersholdBps[party];
 
         // Either threshold is 0 or signer votes above threshold
         if (
-            thresholdBips == 0 ||
-            (signerVotingPowerBips > totalVotingPower &&
-                signerVotingPowerBips / totalVotingPower >= thresholdBips)
+            thresholdBps == 0 ||
+            (signerVotingPowerBps > totalVotingPower &&
+                signerVotingPowerBps / totalVotingPower >= thresholdBps)
         ) {
             return IERC1271.isValidSignature.selector;
         }
@@ -77,11 +77,11 @@ contract OffChainSignatureValidator is IERC1271 {
         revert InsufficientVotingPower();
     }
 
-    /// @notice Set the signing threshold BIPS for the party to validate off-chain signatures
-    /// @param thresholdBips The new threshold BIPS
-    function setSigningThersholdBips(uint96 thresholdBips) external {
+    /// @notice Set the signing threshold BPS for the party to validate off-chain signatures
+    /// @param thresholdBps The new threshold BPS
+    function setSigningThersholdBps(uint96 thresholdBps) external {
         Party party = Party(payable(msg.sender));
-        emit SigningThresholdBipsSet(party, signingThersholdBips[party], thresholdBips);
-        signingThersholdBips[party] = thresholdBips;
+        emit SigningThresholdBpsSet(party, signingThersholdBps[party], thresholdBps);
+        signingThersholdBps[party] = thresholdBps;
     }
 }

--- a/contracts/signature-validators/OffChainSignatureValidator.sol
+++ b/contracts/signature-validators/OffChainSignatureValidator.sol
@@ -11,7 +11,11 @@ contract OffChainSignatureValidator is IERC1271 {
     error InsufficientVotingPower();
     error MessageHashMismatch();
 
-    event SigningThresholdBipsSet(Party party, uint96 oldThresholdBips, uint96 newThresholdBips);
+    event SigningThresholdBipsSet(
+        Party indexed party,
+        uint96 oldThresholdBips,
+        uint96 newThresholdBips
+    );
 
     mapping(Party party => uint96 thresholdBips) public signingThersholdBips;
 

--- a/contracts/signature-validators/OffChainSignatureValidator.sol
+++ b/contracts/signature-validators/OffChainSignatureValidator.sol
@@ -35,13 +35,12 @@ contract OffChainSignatureValidator is IERC1271 {
             v := mload(add(signature, 0x41))
         }
 
-        bytes memory rawMessageData;
+        bytes memory message;
         assembly {
-            // Raw message data begins after v. Overwriting part of s and v with size of `rawMessageData`
-            rawMessageData := add(signature, 0x41)
-            mstore(rawMessageData, sub(mload(signature), 0x41))
+            // Raw message data begins after v. Overwriting part of s and v with size of `message`
+            message := add(signature, 0x41)
+            mstore(message, sub(mload(signature), 0x41))
         }
-        bytes memory message = abi.encodePacked(abi.decode(rawMessageData, (string)));
 
         // Recreate the message pre-hash from the raw data
         bytes memory encodedPacket = abi.encodePacked(

--- a/test/TestUsers.sol
+++ b/test/TestUsers.sol
@@ -46,6 +46,10 @@ contract GlobalsAdmin is Test {
     function setRendererStorage(address rendererStorage) public {
         globals.setAddress(LibGlobals.GLOBAL_RENDERER_STORAGE, rendererStorage);
     }
+
+    function setOffChainSignatureValidator(address signatureValidator) public {
+        globals.setAddress(LibGlobals.GLOBAL_OFF_CHAIN_SIGNATURE_VALIDATOR, signatureValidator);
+    }
 }
 
 contract PartyAdmin is Test {

--- a/test/proposals/ListOnZoraProposalForked.t.sol
+++ b/test/proposals/ListOnZoraProposalForked.t.sol
@@ -68,7 +68,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
             PartyGovernance.Proposal memory proposal,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _buildZoraProposal();
-        uint256 proposalId = proposeAndPassProposal(proposal);
+        uint256 proposalId = _proposeAndPassProposal(proposal);
         _expectEmit3();
         emit AuctionCreated(
             proposalData.token,
@@ -92,7 +92,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
             proposalData.duration,
             uint40(block.timestamp + proposalData.timeout)
         );
-        executeProposal(proposalId, proposal);
+        _executeProposal(proposalId, proposal);
     }
 
     function testForked_canBidOnListing() external onlyForked {
@@ -100,7 +100,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
             PartyGovernance.Proposal memory proposal,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _buildZoraProposal();
-        proposePassAndExecuteProposal(proposal);
+        _proposePassAndExecuteProposal(proposal);
         _bidOnListing(proposalData.token, proposalData.tokenId, proposalData.listPrice);
     }
 
@@ -109,7 +109,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
             PartyGovernance.Proposal memory proposal,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _buildZoraProposal();
-        (uint256 proposalId, bytes memory progressData) = proposePassAndExecuteProposal(proposal);
+        (uint256 proposalId, bytes memory progressData) = _proposePassAndExecuteProposal(proposal);
         uint32 auctionStartTime = uint32(block.timestamp);
         skip(proposalData.timeout);
         _expectEmit3();
@@ -129,7 +129,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
         );
         _expectEmit3();
         emit ZoraAuctionExpired(proposalData.token, proposalData.tokenId, block.timestamp);
-        executeProposal(proposalId, proposal, progressData);
+        _executeProposal(proposalId, proposal, progressData);
     }
 
     function testForked_cannotCancelUnexpiredListing() external onlyForked {
@@ -137,7 +137,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
             PartyGovernance.Proposal memory proposal,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _buildZoraProposal();
-        (uint256 proposalId, bytes memory progressData) = proposePassAndExecuteProposal(proposal);
+        (uint256 proposalId, bytes memory progressData) = _proposePassAndExecuteProposal(proposal);
         skip(proposalData.timeout - 1);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -147,7 +147,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
                 block.timestamp + 1
             )
         );
-        executeProposal(proposalId, proposal, progressData);
+        _executeProposal(proposalId, proposal, progressData);
     }
 
     function testForked_cannotSettleOngoingListing() external onlyForked {
@@ -155,7 +155,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
             PartyGovernance.Proposal memory proposal,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _buildZoraProposal();
-        (uint256 proposalId, bytes memory progressData) = proposePassAndExecuteProposal(proposal);
+        (uint256 proposalId, bytes memory progressData) = _proposePassAndExecuteProposal(proposal);
         _bidOnListing(proposalData.token, proposalData.tokenId, proposalData.listPrice);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -165,7 +165,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
                 block.timestamp + proposalData.duration
             )
         );
-        executeProposal(proposalId, proposal, progressData);
+        _executeProposal(proposalId, proposal, progressData);
     }
 
     function testForked_canSettleSuccessfulListing() external onlyForked {
@@ -173,7 +173,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
             PartyGovernance.Proposal memory proposal,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _buildZoraProposal();
-        (uint256 proposalId, bytes memory progressData) = proposePassAndExecuteProposal(proposal);
+        (uint256 proposalId, bytes memory progressData) = _proposePassAndExecuteProposal(proposal);
         uint32 auctionStartTime = uint32(block.timestamp);
         _bidOnListing(john, proposalData.token, proposalData.tokenId, proposalData.listPrice);
         skip(proposalData.duration);
@@ -194,7 +194,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
         );
         _expectEmit3();
         emit ZoraAuctionSold(proposalData.token, proposalData.tokenId);
-        assertTrue(executeProposal(proposalId, proposal, progressData).length == 0);
+        assertTrue(_executeProposal(proposalId, proposal, progressData).length == 0);
         assertEq(address(party).balance, proposalData.listPrice);
     }
 
@@ -203,7 +203,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
             PartyGovernance.Proposal memory proposal,
             ListOnZoraProposal.ZoraProposalData memory proposalData
         ) = _buildZoraProposal();
-        (uint256 proposalId, bytes memory progressData) = proposePassAndExecuteProposal(proposal);
+        (uint256 proposalId, bytes memory progressData) = _proposePassAndExecuteProposal(proposal);
         uint32 auctionStartTime = uint32(block.timestamp);
         _bidOnListing(john, proposalData.token, proposalData.tokenId, proposalData.listPrice);
         skip(proposalData.duration);
@@ -225,7 +225,7 @@ contract ListOnZoraProposalForkedTest is SetupPartyHelper {
         ZORA.settleAuction(proposalData.token, proposalData.tokenId);
         _expectEmit3();
         emit ZoraAuctionSold(proposalData.token, proposalData.tokenId);
-        assertTrue(executeProposal(proposalId, proposal, progressData).length == 0);
+        assertTrue(_executeProposal(proposalId, proposal, progressData).length == 0);
         assertEq(address(party).balance, proposalData.listPrice);
     }
 

--- a/test/proposals/SetSignatureValidatorProposal.t.sol
+++ b/test/proposals/SetSignatureValidatorProposal.t.sol
@@ -1,82 +1,17 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8;
 
-import { Test } from "forge-std/Test.sol";
+import { SetupPartyHelper } from "../utils/SetupPartyHelper.sol";
 import { SetSignatureValidatorProposal } from "../../contracts/proposals/SetSignatureValidatorProposal.sol";
 import { IERC1271 } from "openzeppelin/contracts/interfaces/IERC1271.sol";
-import { IERC721 } from "../../contracts/tokens/IERC721.sol";
-import { GlobalsAdmin } from "../TestUsers.sol";
-import { PartyFactory } from "../../contracts/party/PartyFactory.sol";
-import { Globals } from "../../contracts/globals/Globals.sol";
-import { Party } from "../../contracts/party/Party.sol";
 import { ProposalExecutionEngine } from "../../contracts/proposals/ProposalExecutionEngine.sol";
-import { IFractionalV1VaultFactory } from "../../contracts/proposals/vendor/FractionalV1.sol";
-import { MockZoraReserveAuctionCoreEth } from "./MockZoraReserveAuctionCoreEth.sol";
 import { PartyGovernance } from "../../contracts/party/PartyGovernance.sol";
 import { OffChainSignatureValidator } from "../../contracts/signature-validators/OffChainSignatureValidator.sol";
 
-contract SetSignatureValidatorProposalTest is Test {
+contract SetSignatureValidatorProposalTest is SetupPartyHelper {
+    constructor() SetupPartyHelper(false) {}
+
     event SignatureValidatorSet(bytes32 indexed hash, IERC1271 indexed signatureValidator);
-
-    GlobalsAdmin globalsAdmin;
-    Globals globals;
-    Party party;
-    PartyFactory partyFactory;
-    uint256 internal johnPk = 0xa11ce;
-    uint256 internal dannyPk = 0xb0b;
-    uint256 internal stevePk = 0xca1;
-    address internal john = vm.addr(johnPk);
-    address internal danny = vm.addr(dannyPk);
-    address internal steve = vm.addr(stevePk);
-    IERC721[] preciousTokens = new IERC721[](0);
-    uint256[] preciousTokenIds = new uint256[](0);
-    uint40 internal constant _EXECUTION_DELAY = 300;
-
-    function setUp() public {
-        globalsAdmin = new GlobalsAdmin();
-        globals = globalsAdmin.globals();
-        Party partyImpl = new Party(globals);
-        address globalDaoWalletAddress = address(420);
-        globalsAdmin.setGlobalDaoWallet(globalDaoWalletAddress);
-
-        ProposalExecutionEngine pe = new ProposalExecutionEngine(
-            globals,
-            new MockZoraReserveAuctionCoreEth(),
-            IFractionalV1VaultFactory(address(0))
-        );
-        globalsAdmin.setProposalEng(address(pe));
-
-        OffChainSignatureValidator offChainGlobalValidator = new OffChainSignatureValidator();
-        globalsAdmin.setOffChainSignatureValidator(address(offChainGlobalValidator));
-
-        Party.PartyOptions memory opts;
-        address[] memory hosts = new address[](1);
-        hosts[0] = address(420);
-        opts.name = "PARTY";
-        opts.symbol = "PR-T";
-        opts.governance.hosts = hosts;
-        opts.governance.voteDuration = 99;
-        opts.governance.executionDelay = _EXECUTION_DELAY;
-        opts.governance.passThresholdBps = 1000;
-        opts.governance.totalVotingPower = 300;
-
-        partyFactory = new PartyFactory();
-        address[] memory authorities = new address[](1);
-        authorities[0] = address(this);
-        party = partyFactory.createParty(
-            partyImpl,
-            authorities,
-            opts,
-            preciousTokens,
-            preciousTokenIds,
-            0
-        );
-        party.mint(john, 100, john);
-        party.mint(danny, 100, danny);
-        party.mint(steve, 100, steve);
-        vm.warp(block.timestamp + 100);
-        vm.roll(block.number + 10);
-    }
 
     function testSetValidatorForHash() public {
         PartyGovernance.Proposal memory proposal = _createTestProposal(
@@ -84,15 +19,11 @@ contract SetSignatureValidatorProposalTest is Test {
             IERC1271(address(1))
         );
 
-        vm.prank(john);
-        uint256 proposalId = party.propose(proposal, 0);
-
-        vm.warp(block.timestamp + _EXECUTION_DELAY);
+        uint256 proposalId = _proposeAndPassProposal(proposal);
 
         vm.expectEmit(true, true, true, true);
         emit SignatureValidatorSet(keccak256("hello"), IERC1271(address(1)));
-        vm.prank(john);
-        party.execute(proposalId, proposal, preciousTokens, preciousTokenIds, "", "");
+        _executeProposal(proposalId, proposal);
 
         assertEq(_getValidatorForHash(keccak256("hello")), address(1));
     }
@@ -171,16 +102,11 @@ contract SetSignatureValidatorProposalTest is Test {
 
     function _setValidatorForHash(bytes32 hash, IERC1271 validator) internal {
         PartyGovernance.Proposal memory proposal = _createTestProposal(hash, validator);
-
-        vm.prank(john);
-        uint256 proposalId = party.propose(proposal, 0);
-
-        vm.warp(block.timestamp + _EXECUTION_DELAY);
+        uint256 proposalId = _proposeAndPassProposal(proposal);
 
         vm.expectEmit(true, true, true, true);
         emit SignatureValidatorSet(hash, validator);
-        vm.prank(john);
-        party.execute(proposalId, proposal, preciousTokens, preciousTokenIds, "", "");
+        _executeProposal(proposalId, proposal);
     }
 
     function _createTestProposal(

--- a/test/proposals/SetSignatureValidatorProposal.t.sol
+++ b/test/proposals/SetSignatureValidatorProposal.t.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8;
+
+import { Test } from "forge-std/Test.sol";
+import { TestUtils } from "../TestUtils.sol";
+import { SetSignatureValidatorProposal } from "../../contracts/proposals/SetSignatureValidatorProposal.sol";
+import { IProposalExecutionEngine } from "../../contracts/proposals/IProposalExecutionEngine.sol";
+import { IERC1271 } from "openzeppelin/contracts/interfaces/IERC1271.sol";
+import { IERC721 } from "../../contracts/tokens/IERC721.sol";
+import { PartyParticipant, GlobalsAdmin, PartyAdmin } from "../TestUsers.sol";
+import { PartyFactory } from "../../contracts/party/PartyFactory.sol";
+import { Globals } from "../../contracts/globals/Globals.sol";
+import { Party } from "../../contracts/party/Party.sol";
+import { TokenDistributor } from "../../contracts/distribution/TokenDistributor.sol";
+import { ProposalExecutionEngine } from "../../contracts/proposals/ProposalExecutionEngine.sol";
+import { IFractionalV1VaultFactory } from "../../contracts/proposals/vendor/FractionalV1.sol";
+import { MockZoraReserveAuctionCoreEth } from "./MockZoraReserveAuctionCoreEth.sol";
+import { PartyGovernance } from "../../contracts/party/PartyGovernance.sol";
+
+contract SetSignatureValidatorProposalTest is Test, TestUtils {
+    event SignatureValidatorSet(bytes32 indexed hash, IERC1271 indexed signatureValidator);
+
+    GlobalsAdmin globalsAdmin;
+    Globals globals;
+    Party party;
+    TokenDistributor tokenDistributor;
+    PartyFactory partyFactory;
+    uint256 internal johnPk = 0xa11ce;
+    uint256 internal dannyPk = 0xb0b;
+    uint256 internal stevePk = 0xca1;
+    address internal john = vm.addr(johnPk);
+    address internal danny = vm.addr(dannyPk);
+    address internal steve = vm.addr(stevePk);
+    IERC721[] preciousTokens = new IERC721[](0);
+    uint256[] preciousTokenIds = new uint256[](0);
+    uint40 internal constant _EXECUTION_DELAY = 300;
+
+    function setUp() public {
+        globalsAdmin = new GlobalsAdmin();
+        globals = globalsAdmin.globals();
+        Party partyImpl = new Party(globals);
+        address globalDaoWalletAddress = address(420);
+        globalsAdmin.setGlobalDaoWallet(globalDaoWalletAddress);
+
+        tokenDistributor = new TokenDistributor(globals, 0);
+        globalsAdmin.setTokenDistributor(address(tokenDistributor));
+
+        ProposalExecutionEngine pe = new ProposalExecutionEngine(
+            globals,
+            new MockZoraReserveAuctionCoreEth(),
+            IFractionalV1VaultFactory(address(0))
+        );
+        globalsAdmin.setProposalEng(address(pe));
+
+        Party.PartyOptions memory opts;
+        address[] memory hosts = new address[](1);
+        hosts[0] = address(420);
+        opts.name = "PARTY";
+        opts.symbol = "PR-T";
+        opts.governance.hosts = hosts;
+        opts.governance.voteDuration = 99;
+        opts.governance.executionDelay = _EXECUTION_DELAY;
+        opts.governance.passThresholdBps = 1000;
+        opts.governance.totalVotingPower = 300;
+
+        partyFactory = new PartyFactory();
+        address[] memory authorities = new address[](1);
+        authorities[0] = address(this);
+        party = partyFactory.createParty(
+            partyImpl,
+            authorities,
+            opts,
+            preciousTokens,
+            preciousTokenIds,
+            0
+        );
+        party.mint(john, 100, john);
+        party.mint(danny, 100, danny);
+        party.mint(steve, 100, steve);
+        vm.warp(block.timestamp + 100);
+        vm.roll(block.number + 10);
+    }
+
+    function testSetValidatorForHash() public {
+        PartyGovernance.Proposal memory proposal = _createTestProposal(
+            keccak256("hello"),
+            IERC1271(address(1))
+        );
+
+        vm.prank(john);
+        uint256 proposalId = party.propose(proposal, 0);
+
+        vm.warp(block.timestamp + _EXECUTION_DELAY);
+
+        vm.expectEmit(true, true, true, true);
+        emit SignatureValidatorSet(keccak256("hello"), IERC1271(address(1)));
+        vm.prank(john);
+        party.execute(proposalId, proposal, preciousTokens, preciousTokenIds, "", "");
+
+        assertEq(_getValidatorForHash(keccak256("hello")), address(1));
+    }
+
+    function _createTestProposal(
+        bytes32 hash,
+        IERC1271 validator
+    ) private view returns (PartyGovernance.Proposal memory proposal) {
+        SetSignatureValidatorProposal.SetSignatureValidatorProposalData
+            memory data = SetSignatureValidatorProposal.SetSignatureValidatorProposalData({
+                signatureHash: hash,
+                signatureValidator: validator
+            });
+
+        proposal = PartyGovernance.Proposal({
+            maxExecutableTime: type(uint40).max,
+            cancelDelay: 0,
+            proposalData: abi.encodeWithSelector(
+                bytes4(uint32(ProposalExecutionEngine.ProposalType.SetSignatureValidatorProposal)),
+                data
+            )
+        });
+    }
+
+    function _getValidatorForHash(bytes32 hash) internal returns (address) {
+        (bool success, bytes memory res) = address(party).staticcall(
+            abi.encodeWithSelector(
+                SetSignatureValidatorProposal.getSignatureValidatorForHash.selector,
+                hash
+            )
+        );
+        assertTrue(success);
+        return abi.decode(res, (address));
+    }
+}

--- a/test/proposals/SetSignatureValidatorProposal.t.sol
+++ b/test/proposals/SetSignatureValidatorProposal.t.sol
@@ -2,29 +2,25 @@
 pragma solidity ^0.8;
 
 import { Test } from "forge-std/Test.sol";
-import { TestUtils } from "../TestUtils.sol";
 import { SetSignatureValidatorProposal } from "../../contracts/proposals/SetSignatureValidatorProposal.sol";
-import { IProposalExecutionEngine } from "../../contracts/proposals/IProposalExecutionEngine.sol";
 import { IERC1271 } from "openzeppelin/contracts/interfaces/IERC1271.sol";
 import { IERC721 } from "../../contracts/tokens/IERC721.sol";
-import { PartyParticipant, GlobalsAdmin, PartyAdmin } from "../TestUsers.sol";
+import { GlobalsAdmin } from "../TestUsers.sol";
 import { PartyFactory } from "../../contracts/party/PartyFactory.sol";
 import { Globals } from "../../contracts/globals/Globals.sol";
 import { Party } from "../../contracts/party/Party.sol";
-import { TokenDistributor } from "../../contracts/distribution/TokenDistributor.sol";
 import { ProposalExecutionEngine } from "../../contracts/proposals/ProposalExecutionEngine.sol";
 import { IFractionalV1VaultFactory } from "../../contracts/proposals/vendor/FractionalV1.sol";
 import { MockZoraReserveAuctionCoreEth } from "./MockZoraReserveAuctionCoreEth.sol";
 import { PartyGovernance } from "../../contracts/party/PartyGovernance.sol";
 import { OffChainSignatureValidator } from "../../contracts/signature-validators/OffChainSignatureValidator.sol";
 
-contract SetSignatureValidatorProposalTest is Test, TestUtils {
+contract SetSignatureValidatorProposalTest is Test {
     event SignatureValidatorSet(bytes32 indexed hash, IERC1271 indexed signatureValidator);
 
     GlobalsAdmin globalsAdmin;
     Globals globals;
     Party party;
-    TokenDistributor tokenDistributor;
     PartyFactory partyFactory;
     uint256 internal johnPk = 0xa11ce;
     uint256 internal dannyPk = 0xb0b;
@@ -42,9 +38,6 @@ contract SetSignatureValidatorProposalTest is Test, TestUtils {
         Party partyImpl = new Party(globals);
         address globalDaoWalletAddress = address(420);
         globalsAdmin.setGlobalDaoWallet(globalDaoWalletAddress);
-
-        tokenDistributor = new TokenDistributor(globals, 0);
-        globalsAdmin.setTokenDistributor(address(tokenDistributor));
 
         ProposalExecutionEngine pe = new ProposalExecutionEngine(
             globals,

--- a/test/proposals/SetSignatureValidatorProposal.t.sol
+++ b/test/proposals/SetSignatureValidatorProposal.t.sol
@@ -129,7 +129,7 @@ contract SetSignatureValidatorProposalTest is Test, TestUtils {
         assertEq(abi.decode(res, (bytes4)), 0);
     }
 
-    function testValidatorSet() public {
+    function testValidatorSetToExternalValidator() public {
         MockValdidator validator = new MockValdidator();
         _setValidatorForHash(keccak256("hello"), validator);
 
@@ -152,6 +152,16 @@ contract SetSignatureValidatorProposalTest is Test, TestUtils {
     function testOverrideDefaultOffChainValidator() public {
         MockValdidator validator = new MockValdidator();
         _setValidatorForHash(0, validator);
+
+        bytes memory staticCallData = abi.encodeWithSelector(
+            IERC1271.isValidSignature.selector,
+            keccak256("hello"),
+            "0x"
+        );
+        vm.startPrank(address(0), address(0));
+        (bool success, bytes memory res) = address(party).staticcall(staticCallData);
+        assertTrue(success);
+        assertEq(abi.decode(res, (bytes4)), IERC1271.isValidSignature.selector);
     }
 
     function testDefaultOffChainValidatorCalled() public {

--- a/test/signature-validators/OffChainSignatureValidator.t.sol
+++ b/test/signature-validators/OffChainSignatureValidator.t.sol
@@ -112,7 +112,7 @@ contract OffChainSignatureValidatorTest is SetupPartyHelper {
         vm.prank(address(party));
         vm.expectEmit(true, true, true, true);
         emit SigningThresholdBpsSet(party, 0, 5000);
-        offChainGlobalValidator.setSigningThersholdBps(5000);
+        offChainGlobalValidator.setSigningThresholdBps(5000);
 
         vm.prank(address(0), address(0));
         (bool success, bytes memory res) = address(party).staticcall(staticCallData);
@@ -120,7 +120,7 @@ contract OffChainSignatureValidatorTest is SetupPartyHelper {
         _assertEqual(res, OffChainSignatureValidator.InsufficientVotingPower.selector);
 
         vm.prank(address(party));
-        offChainGlobalValidator.setSigningThersholdBps(4000);
+        offChainGlobalValidator.setSigningThresholdBps(4000);
 
         vm.prank(address(0), address(0));
         // Now sufficient
@@ -142,7 +142,7 @@ contract OffChainSignatureValidatorTest is SetupPartyHelper {
         );
 
         vm.prank(address(party));
-        offChainGlobalValidator.setSigningThersholdBps(1000);
+        offChainGlobalValidator.setSigningThresholdBps(1000);
 
         vm.prank(address(0), address(0));
         (bool success, bytes memory res) = address(party).staticcall(staticCallData);

--- a/test/signature-validators/OffChainSignatureValidator.t.sol
+++ b/test/signature-validators/OffChainSignatureValidator.t.sol
@@ -1,85 +1,40 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8;
 
-import { Test } from "forge-std/Test.sol";
+import { SetupPartyHelper } from "../utils/SetupPartyHelper.sol";
 import { SetSignatureValidatorProposal } from "../../contracts/proposals/SetSignatureValidatorProposal.sol";
 import { IERC1271 } from "openzeppelin/contracts/interfaces/IERC1271.sol";
-import { IERC721 } from "../../contracts/tokens/IERC721.sol";
-import { GlobalsAdmin } from "../TestUsers.sol";
-import { PartyFactory } from "../../contracts/party/PartyFactory.sol";
-import { Globals } from "../../contracts/globals/Globals.sol";
 import { Party } from "../../contracts/party/Party.sol";
 import { ProposalExecutionEngine } from "../../contracts/proposals/ProposalExecutionEngine.sol";
-import { IFractionalV1VaultFactory } from "../../contracts/proposals/vendor/FractionalV1.sol";
-import { MockZoraReserveAuctionCoreEth } from "../proposals/MockZoraReserveAuctionCoreEth.sol";
 import { PartyGovernance } from "../../contracts/party/PartyGovernance.sol";
 import { OffChainSignatureValidator } from "../../contracts/signature-validators/OffChainSignatureValidator.sol";
 import { Strings } from "openzeppelin/contracts/utils/Strings.sol";
+import { LibGlobals } from "../../contracts/Globals/LibGlobals.sol";
 
-contract OffChainSignatureValidatorTest is Test {
+contract OffChainSignatureValidatorTest is SetupPartyHelper {
+    constructor() SetupPartyHelper(false) {}
+
+    OffChainSignatureValidator offChainGlobalValidator;
+
     event SigningThresholdBpsSet(
         Party indexed party,
         uint96 oldThresholdBps,
         uint96 newThresholdBps
     );
 
-    GlobalsAdmin globalsAdmin;
-    Globals globals;
-    Party party;
-    PartyFactory partyFactory;
-    OffChainSignatureValidator offChainGlobalValidator = new OffChainSignatureValidator();
-    uint256 internal johnPk = 0xa11ce;
-    uint256 internal dannyPk = 0xb0b;
-    uint256 internal stevePk = 0xca1;
-    address internal john = vm.addr(johnPk);
-    address internal danny = vm.addr(dannyPk);
-    address internal steve = vm.addr(stevePk);
-    IERC721[] preciousTokens = new IERC721[](0);
-    uint256[] preciousTokenIds = new uint256[](0);
-    uint40 internal constant _EXECUTION_DELAY = 300;
-
-    function setUp() public {
-        globalsAdmin = new GlobalsAdmin();
-        globals = globalsAdmin.globals();
-        Party partyImpl = new Party(globals);
-        address globalDaoWalletAddress = address(420);
-        globalsAdmin.setGlobalDaoWallet(globalDaoWalletAddress);
-
-        ProposalExecutionEngine pe = new ProposalExecutionEngine(
-            globals,
-            new MockZoraReserveAuctionCoreEth(),
-            IFractionalV1VaultFactory(address(0))
+    function setUp() public override {
+        setUpWithParams(
+            SetupPartyHelper.SetupPartyParams({
+                johnVotes: 1000,
+                dannyVotes: 1000,
+                steveVotes: 1,
+                thisVotes: 1
+            })
         );
-        globalsAdmin.setProposalEng(address(pe));
-        globalsAdmin.setOffChainSignatureValidator(address(offChainGlobalValidator));
 
-        Party.PartyOptions memory opts;
-        address[] memory hosts = new address[](1);
-        hosts[0] = address(420);
-        opts.name = "PARTY";
-        opts.symbol = "PR-T";
-        opts.governance.hosts = hosts;
-        opts.governance.voteDuration = 99;
-        opts.governance.executionDelay = _EXECUTION_DELAY;
-        opts.governance.passThresholdBps = 1000;
-        opts.governance.totalVotingPower = 20001;
-
-        partyFactory = new PartyFactory();
-        address[] memory authorities = new address[](1);
-        authorities[0] = address(this);
-        party = partyFactory.createParty(
-            partyImpl,
-            authorities,
-            opts,
-            preciousTokens,
-            preciousTokenIds,
-            0
+        offChainGlobalValidator = OffChainSignatureValidator(
+            globals.getAddress(LibGlobals.GLOBAL_OFF_CHAIN_SIGNATURE_VALIDATOR)
         );
-        party.mint(john, 10000, john);
-        party.mint(danny, 10000, danny);
-        party.mint(steve, 1, steve);
-        vm.warp(block.timestamp + 100);
-        vm.roll(block.number + 10);
     }
 
     function testOffChainMessageValidation() public {
@@ -248,14 +203,7 @@ contract OffChainSignatureValidatorTest is Test {
 
     function _setValidatorForHash(bytes32 hash, IERC1271 validator) internal {
         PartyGovernance.Proposal memory proposal = _createTestProposal(hash, validator);
-
-        vm.prank(john);
-        uint256 proposalId = party.propose(proposal, 0);
-
-        vm.warp(block.timestamp + _EXECUTION_DELAY);
-
-        vm.prank(john);
-        party.execute(proposalId, proposal, preciousTokens, preciousTokenIds, "", "");
+        _proposePassAndExecuteProposal(proposal);
     }
 
     function _createTestProposal(

--- a/test/signature-validators/OffChainSignatureValidator.t.sol
+++ b/test/signature-validators/OffChainSignatureValidator.t.sol
@@ -243,7 +243,7 @@ contract OffChainSignatureValidatorTest is Test {
         );
         messageHash = keccak256(encodedPacket);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, messageHash);
-        signature = abi.encodePacked(r, s, v, abi.encode(message));
+        signature = abi.encodePacked(r, s, v, abi.encodePacked(message));
     }
 
     function _setValidatorForHash(bytes32 hash, IERC1271 validator) internal {

--- a/test/signature-validators/OffChainSignatureValidator.t.sol
+++ b/test/signature-validators/OffChainSignatureValidator.t.sol
@@ -17,10 +17,10 @@ import { OffChainSignatureValidator } from "../../contracts/signature-validators
 import { Strings } from "openzeppelin/contracts/utils/Strings.sol";
 
 contract OffChainSignatureValidatorTest is Test {
-    event SigningThresholdBipsSet(
+    event SigningThresholdBpsSet(
         Party indexed party,
-        uint96 oldThresholdBips,
-        uint96 newThresholdBips
+        uint96 oldThresholdBps,
+        uint96 newThresholdBps
     );
 
     GlobalsAdmin globalsAdmin;
@@ -156,8 +156,8 @@ contract OffChainSignatureValidatorTest is Test {
 
         vm.prank(address(party));
         vm.expectEmit(true, true, true, true);
-        emit SigningThresholdBipsSet(party, 0, 5000);
-        offChainGlobalValidator.setSigningThersholdBips(5000);
+        emit SigningThresholdBpsSet(party, 0, 5000);
+        offChainGlobalValidator.setSigningThersholdBps(5000);
 
         vm.prank(address(0), address(0));
         (bool success, bytes memory res) = address(party).staticcall(staticCallData);
@@ -165,7 +165,7 @@ contract OffChainSignatureValidatorTest is Test {
         _assertEqual(res, OffChainSignatureValidator.InsufficientVotingPower.selector);
 
         vm.prank(address(party));
-        offChainGlobalValidator.setSigningThersholdBips(4000);
+        offChainGlobalValidator.setSigningThersholdBps(4000);
 
         vm.prank(address(0), address(0));
         // Now sufficient
@@ -187,7 +187,7 @@ contract OffChainSignatureValidatorTest is Test {
         );
 
         vm.prank(address(party));
-        offChainGlobalValidator.setSigningThersholdBips(1000);
+        offChainGlobalValidator.setSigningThersholdBps(1000);
 
         vm.prank(address(0), address(0));
         (bool success, bytes memory res) = address(party).staticcall(staticCallData);

--- a/test/signature-validators/OffChainSignatureValidator.t.sol
+++ b/test/signature-validators/OffChainSignatureValidator.t.sol
@@ -2,16 +2,13 @@
 pragma solidity ^0.8;
 
 import { Test } from "forge-std/Test.sol";
-import { TestUtils } from "../TestUtils.sol";
 import { SetSignatureValidatorProposal } from "../../contracts/proposals/SetSignatureValidatorProposal.sol";
-import { IProposalExecutionEngine } from "../../contracts/proposals/IProposalExecutionEngine.sol";
 import { IERC1271 } from "openzeppelin/contracts/interfaces/IERC1271.sol";
 import { IERC721 } from "../../contracts/tokens/IERC721.sol";
 import { GlobalsAdmin } from "../TestUsers.sol";
 import { PartyFactory } from "../../contracts/party/PartyFactory.sol";
 import { Globals } from "../../contracts/globals/Globals.sol";
 import { Party } from "../../contracts/party/Party.sol";
-import { TokenDistributor } from "../../contracts/distribution/TokenDistributor.sol";
 import { ProposalExecutionEngine } from "../../contracts/proposals/ProposalExecutionEngine.sol";
 import { IFractionalV1VaultFactory } from "../../contracts/proposals/vendor/FractionalV1.sol";
 import { MockZoraReserveAuctionCoreEth } from "../proposals/MockZoraReserveAuctionCoreEth.sol";
@@ -19,13 +16,16 @@ import { PartyGovernance } from "../../contracts/party/PartyGovernance.sol";
 import { OffChainSignatureValidator } from "../../contracts/signature-validators/OffChainSignatureValidator.sol";
 import { Strings } from "openzeppelin/contracts/utils/Strings.sol";
 
-contract OffChainSignatureValidatorTest is Test, TestUtils {
-    event SigningThresholdBipsSet(Party party, uint96 oldThresholdBips, uint96 newThresholdBips);
+contract OffChainSignatureValidatorTest is Test {
+    event SigningThresholdBipsSet(
+        Party indexed party,
+        uint96 oldThresholdBips,
+        uint96 newThresholdBips
+    );
 
     GlobalsAdmin globalsAdmin;
     Globals globals;
     Party party;
-    TokenDistributor tokenDistributor;
     PartyFactory partyFactory;
     OffChainSignatureValidator offChainGlobalValidator = new OffChainSignatureValidator();
     uint256 internal johnPk = 0xa11ce;
@@ -44,9 +44,6 @@ contract OffChainSignatureValidatorTest is Test, TestUtils {
         Party partyImpl = new Party(globals);
         address globalDaoWalletAddress = address(420);
         globalsAdmin.setGlobalDaoWallet(globalDaoWalletAddress);
-
-        tokenDistributor = new TokenDistributor(globals, 0);
-        globalsAdmin.setTokenDistributor(address(tokenDistributor));
 
         ProposalExecutionEngine pe = new ProposalExecutionEngine(
             globals,

--- a/test/signature-validators/OffChainSignatureValidator.t.sol
+++ b/test/signature-validators/OffChainSignatureValidator.t.sol
@@ -243,7 +243,7 @@ contract OffChainSignatureValidatorTest is Test {
         );
         messageHash = keccak256(encodedPacket);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, messageHash);
-        signature = abi.encodePacked(r, s, v, abi.encodePacked(message));
+        signature = abi.encodePacked(r, s, v, message);
     }
 
     function _setValidatorForHash(bytes32 hash, IERC1271 validator) internal {

--- a/test/signature-validators/OffChainSignatureValidator.t.sol
+++ b/test/signature-validators/OffChainSignatureValidator.t.sol
@@ -9,7 +9,7 @@ import { ProposalExecutionEngine } from "../../contracts/proposals/ProposalExecu
 import { PartyGovernance } from "../../contracts/party/PartyGovernance.sol";
 import { OffChainSignatureValidator } from "../../contracts/signature-validators/OffChainSignatureValidator.sol";
 import { Strings } from "openzeppelin/contracts/utils/Strings.sol";
-import { LibGlobals } from "../../contracts/Globals/LibGlobals.sol";
+import { LibGlobals } from "../../contracts/globals/LibGlobals.sol";
 
 contract OffChainSignatureValidatorTest is SetupPartyHelper {
     constructor() SetupPartyHelper(false) {}

--- a/test/signature-validators/OffChainSignatureValidator.t.sol
+++ b/test/signature-validators/OffChainSignatureValidator.t.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8;
+
+import { Test } from "forge-std/Test.sol";
+import { TestUtils } from "../TestUtils.sol";
+import { SetSignatureValidatorProposal } from "../../contracts/proposals/SetSignatureValidatorProposal.sol";
+import { IProposalExecutionEngine } from "../../contracts/proposals/IProposalExecutionEngine.sol";
+import { IERC1271 } from "openzeppelin/contracts/interfaces/IERC1271.sol";
+import { IERC721 } from "../../contracts/tokens/IERC721.sol";
+import { PartyParticipant, GlobalsAdmin, PartyAdmin } from "../TestUsers.sol";
+import { PartyFactory } from "../../contracts/party/PartyFactory.sol";
+import { Globals } from "../../contracts/globals/Globals.sol";
+import { Party } from "../../contracts/party/Party.sol";
+import { TokenDistributor } from "../../contracts/distribution/TokenDistributor.sol";
+import { ProposalExecutionEngine } from "../../contracts/proposals/ProposalExecutionEngine.sol";
+import { IFractionalV1VaultFactory } from "../../contracts/proposals/vendor/FractionalV1.sol";
+import { MockZoraReserveAuctionCoreEth } from "../proposals/MockZoraReserveAuctionCoreEth.sol";
+import { PartyGovernance } from "../../contracts/party/PartyGovernance.sol";
+import { OffChainSignatureValidator } from "../../contracts/signature-validators/OffChainSignatureValidator.sol";
+import { Strings } from "openzeppelin/contracts/utils/Strings.sol";
+
+contract OffChainSignatureValidatorTest is Test, TestUtils {
+    GlobalsAdmin globalsAdmin;
+    Globals globals;
+    Party party;
+    TokenDistributor tokenDistributor;
+    PartyFactory partyFactory;
+    uint256 internal johnPk = 0xa11ce;
+    uint256 internal dannyPk = 0xb0b;
+    uint256 internal stevePk = 0xca1;
+    address internal john = vm.addr(johnPk);
+    address internal danny = vm.addr(dannyPk);
+    address internal steve = vm.addr(stevePk);
+    IERC721[] preciousTokens = new IERC721[](0);
+    uint256[] preciousTokenIds = new uint256[](0);
+    uint40 internal constant _EXECUTION_DELAY = 300;
+
+    function setUp() public {
+        globalsAdmin = new GlobalsAdmin();
+        globals = globalsAdmin.globals();
+        Party partyImpl = new Party(globals);
+        address globalDaoWalletAddress = address(420);
+        globalsAdmin.setGlobalDaoWallet(globalDaoWalletAddress);
+
+        tokenDistributor = new TokenDistributor(globals, 0);
+        globalsAdmin.setTokenDistributor(address(tokenDistributor));
+
+        ProposalExecutionEngine pe = new ProposalExecutionEngine(
+            globals,
+            new MockZoraReserveAuctionCoreEth(),
+            IFractionalV1VaultFactory(address(0))
+        );
+        globalsAdmin.setProposalEng(address(pe));
+
+        OffChainSignatureValidator offChainGlobalValidator = new OffChainSignatureValidator();
+        globalsAdmin.setOffChainSignatureValidator(address(offChainGlobalValidator));
+
+        Party.PartyOptions memory opts;
+        address[] memory hosts = new address[](1);
+        hosts[0] = address(420);
+        opts.name = "PARTY";
+        opts.symbol = "PR-T";
+        opts.governance.hosts = hosts;
+        opts.governance.voteDuration = 99;
+        opts.governance.executionDelay = _EXECUTION_DELAY;
+        opts.governance.passThresholdBps = 1000;
+        opts.governance.totalVotingPower = 300;
+
+        partyFactory = new PartyFactory();
+        address[] memory authorities = new address[](1);
+        authorities[0] = address(this);
+        party = partyFactory.createParty(
+            partyImpl,
+            authorities,
+            opts,
+            preciousTokens,
+            preciousTokenIds,
+            0
+        );
+        party.mint(john, 100, john);
+        party.mint(danny, 100, danny);
+        party.mint(steve, 100, steve);
+        vm.warp(block.timestamp + 100);
+        vm.roll(block.number + 10);
+    }
+
+    function testOffChainMessageValidation() public {
+        (bytes32 messageHash, bytes memory signature) = _signMessage(
+            johnPk,
+            "Hello World! nonce:1000"
+        );
+
+        bytes memory staticCallData = abi.encodeWithSelector(
+            IERC1271.isValidSignature.selector,
+            messageHash,
+            signature
+        );
+        vm.startPrank(address(0), address(0));
+        (bool success, bytes memory res) = address(party).staticcall(staticCallData);
+        assertTrue(success);
+        assertEq(abi.decode(res, (bytes4)), IERC1271.isValidSignature.selector);
+    }
+
+    function testOffChainMessageValidationNotInParty() public {
+        (bytes32 messageHash, bytes memory signature) = _signMessage(
+            12345634,
+            "Hello World! nonce:1000"
+        );
+
+        bytes memory staticCallData = abi.encodeWithSelector(
+            IERC1271.isValidSignature.selector,
+            messageHash,
+            signature
+        );
+        vm.startPrank(address(0), address(0));
+
+        vm.expectRevert(OffChainSignatureValidator.NotMemberOfParty.selector);
+        address(party).staticcall(staticCallData);
+    }
+
+    function testOffChainMessageValidationMessageHashMismatch() public {
+        bytes memory message = "hello world1";
+        bytes memory encondedMessage = abi.encodePacked(message);
+        bytes memory encodedPacket = abi.encodePacked(
+            "\x19Ethereum Signed Message:\n",
+            Strings.toString(encondedMessage.length),
+            encondedMessage
+        );
+        bytes32 messageHash = keccak256(encodedPacket);
+        messageHash = keccak256(
+            abi.encodePacked(
+                "\x19Ethereum Signed Message:\n",
+                Strings.toString(encondedMessage.length),
+                encondedMessage
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(johnPk, messageHash);
+        bytes memory signature = abi.encodePacked(r, s, v, abi.encode(message));
+
+        vm.startPrank(address(0), address(0));
+
+        bytes memory staticCallData = abi.encodeWithSelector(
+            IERC1271.isValidSignature.selector,
+            messageHash,
+            signature
+        );
+        vm.expectRevert(OffChainSignatureValidator.MessageHashMismatch.selector);
+        address(party).staticcall(staticCallData);
+    }
+
+    function _signMessage(
+        uint256 privateKey,
+        string memory message
+    ) internal pure returns (bytes32 messageHash, bytes memory signature) {
+        bytes memory encondedMessage = abi.encodePacked(message);
+        bytes memory encodedPacket = abi.encodePacked(
+            "\x19Ethereum Signed Message:\n",
+            Strings.toString(encondedMessage.length),
+            encondedMessage
+        );
+        messageHash = keccak256(encodedPacket);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, messageHash);
+        signature = abi.encodePacked(r, s, v, abi.encode(message));
+    }
+
+    function _setValidatorForHash(bytes32 hash, IERC1271 validator) internal {
+        PartyGovernance.Proposal memory proposal = _createTestProposal(hash, validator);
+
+        vm.prank(john);
+        uint256 proposalId = party.propose(proposal, 0);
+
+        vm.warp(block.timestamp + _EXECUTION_DELAY);
+
+        vm.prank(john);
+        party.execute(proposalId, proposal, preciousTokens, preciousTokenIds, "", "");
+    }
+
+    function _createTestProposal(
+        bytes32 hash,
+        IERC1271 validator
+    ) private pure returns (PartyGovernance.Proposal memory proposal) {
+        SetSignatureValidatorProposal.SetSignatureValidatorProposalData
+            memory data = SetSignatureValidatorProposal.SetSignatureValidatorProposalData({
+                signatureHash: hash,
+                signatureValidator: validator
+            });
+
+        proposal = PartyGovernance.Proposal({
+            maxExecutableTime: type(uint40).max,
+            cancelDelay: 0,
+            proposalData: abi.encodeWithSelector(
+                bytes4(uint32(ProposalExecutionEngine.ProposalType.SetSignatureValidatorProposal)),
+                data
+            )
+        });
+    }
+
+    function _getValidatorForHash(bytes32 hash) internal returns (address) {
+        (bool success, bytes memory res) = address(party).staticcall(
+            abi.encodeWithSelector(
+                SetSignatureValidatorProposal.getSignatureValidatorForHash.selector,
+                hash
+            )
+        );
+        assertTrue(success);
+        return abi.decode(res, (address));
+    }
+}

--- a/test/utils/SetupPartyHelper.sol
+++ b/test/utils/SetupPartyHelper.sol
@@ -14,14 +14,22 @@ import { MockZoraReserveAuctionCoreEth } from "../proposals/MockZoraReserveAucti
 import { IReserveAuctionCoreEth } from "../../contracts/vendor/markets/IReserveAuctionCoreEth.sol";
 import { PartyGovernance } from "../../contracts/party/PartyGovernance.sol";
 import { ERC721Receiver } from "../../contracts/tokens/ERC721Receiver.sol";
+import { OffChainSignatureValidator } from "../../contracts/signature-validators/OffChainSignatureValidator.sol";
 
 /// @notice This contract provides a fully functioning party instance for testing.
 ///     Run setup from inheriting contract.
 abstract contract SetupPartyHelper is TestUtils, ERC721Receiver {
+    struct SetupPartyParams {
+        uint96 johnVotes;
+        uint96 dannyVotes;
+        uint96 steveVotes;
+        uint96 thisVotes;
+    }
+
     bool private immutable _isForked;
     GlobalsAdmin globalsAdmin;
     Party party;
-    Globals private globals;
+    Globals internal globals;
     PartyFactory private partyFactory;
     uint256 internal johnPk = 0xa11ce;
     uint256 internal dannyPk = 0xb0b;
@@ -29,12 +37,24 @@ abstract contract SetupPartyHelper is TestUtils, ERC721Receiver {
     address internal john = vm.addr(johnPk);
     address internal danny = vm.addr(dannyPk);
     address internal steve = vm.addr(stevePk);
+    uint96 internal johnVotes;
+    uint96 internal dannyVotes;
+    uint96 internal steveVotes;
+    uint96 internal thisVotes;
     IERC721[] private preciousTokens = new IERC721[](0);
     uint256[] private preciousTokenIds = new uint256[](0);
     uint40 private constant _EXECUTION_DELAY = 300;
 
     constructor(bool isForked) {
         _isForked = isForked;
+    }
+
+    function setUpWithParams(SetupPartyParams memory params) public {
+        johnVotes = params.johnVotes;
+        dannyVotes = params.dannyVotes;
+        steveVotes = params.steveVotes;
+        thisVotes = params.thisVotes;
+        SetupPartyHelper.setUp();
     }
 
     function setUp() public virtual {
@@ -56,6 +76,14 @@ abstract contract SetupPartyHelper is TestUtils, ERC721Receiver {
 
         globalsAdmin.setProposalEng(address(pe));
 
+        OffChainSignatureValidator offChainGlobalValidator = new OffChainSignatureValidator();
+        globalsAdmin.setOffChainSignatureValidator(address(offChainGlobalValidator));
+
+        johnVotes = johnVotes == 0 ? 100 : johnVotes;
+        dannyVotes = dannyVotes == 0 ? 100 : dannyVotes;
+        steveVotes = steveVotes == 0 ? 100 : steveVotes;
+        thisVotes = thisVotes == 0 ? 1 : thisVotes;
+
         Party.PartyOptions memory opts;
         address[] memory hosts = new address[](1);
         hosts[0] = address(420);
@@ -65,7 +93,7 @@ abstract contract SetupPartyHelper is TestUtils, ERC721Receiver {
         opts.governance.voteDuration = 99;
         opts.governance.executionDelay = _EXECUTION_DELAY;
         opts.governance.passThresholdBps = 1000;
-        opts.governance.totalVotingPower = 301;
+        opts.governance.totalVotingPower = johnVotes + dannyVotes + steveVotes + thisVotes;
 
         partyFactory = new PartyFactory();
         address[] memory authorities = new address[](1);
@@ -78,10 +106,10 @@ abstract contract SetupPartyHelper is TestUtils, ERC721Receiver {
             preciousTokenIds,
             0
         );
-        party.mint(john, 100, john);
-        party.mint(danny, 100, danny);
-        party.mint(steve, 100, steve);
-        party.mint(address(this), 1, address(this));
+        party.mint(john, johnVotes, john);
+        party.mint(danny, dannyVotes, danny);
+        party.mint(steve, steveVotes, steve);
+        party.mint(address(this), thisVotes, address(this));
         vm.warp(block.timestamp + 100);
         vm.roll(block.number + 10);
     }
@@ -89,7 +117,7 @@ abstract contract SetupPartyHelper is TestUtils, ERC721Receiver {
     /// @notice Propose pass and wait for the execution delay of a proposal
     /// @param proposal The `PartyGovernance.Proposal` struct representing the proposal
     /// @return proposalId The proposal id for the proposal
-    function proposeAndPassProposal(
+    function _proposeAndPassProposal(
         PartyGovernance.Proposal memory proposal
     ) internal returns (uint256 proposalId) {
         vm.prank(john);
@@ -102,11 +130,11 @@ abstract contract SetupPartyHelper is TestUtils, ERC721Receiver {
     /// @param proposal The `PartyGovernance.Proposal` struct representing the proposal
     /// @return proposalId The proposal id for the proposal
     /// @return progressData The progress data returned from the proposal execution
-    function proposePassAndExecuteProposal(
+    function _proposePassAndExecuteProposal(
         PartyGovernance.Proposal memory proposal
     ) internal returns (uint256, bytes memory) {
-        uint256 proposalId = proposeAndPassProposal(proposal);
-        bytes memory progressData = executeProposal(proposalId, proposal);
+        uint256 proposalId = _proposeAndPassProposal(proposal);
+        bytes memory progressData = _executeProposal(proposalId, proposal);
         return (proposalId, progressData);
     }
 
@@ -114,11 +142,11 @@ abstract contract SetupPartyHelper is TestUtils, ERC721Receiver {
     /// @param proposalId The proposal id for the proposal
     /// @param proposal The `PartyGovernance.Proposal` struct representing the proposal
     /// @return progressData The progress data returned from the proposal execution
-    function executeProposal(
+    function _executeProposal(
         uint256 proposalId,
         PartyGovernance.Proposal memory proposal
     ) internal returns (bytes memory) {
-        return executeProposal(proposalId, proposal, "");
+        return _executeProposal(proposalId, proposal, "");
     }
 
     /// @notice Execute the given proposal with `progressData`
@@ -126,7 +154,7 @@ abstract contract SetupPartyHelper is TestUtils, ERC721Receiver {
     /// @param proposal The `PartyGovernance.Proposal` struct representing the proposal
     /// @param progressData The progress data to pass to the proposal execution
     /// @return progressData The progress data returned from the proposal execution
-    function executeProposal(
+    function _executeProposal(
         uint256 proposalId,
         PartyGovernance.Proposal memory proposal,
         bytes memory progressData


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Parties want to be able to sign messages via the ERC1271 spec. Without this ability, they can't sign into any websites that are signature gated or sign messages to interact with services.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
We implement ERC1271 on the `ProposalExecutionEngine` which is the fallback for static calls to each party. This method delegates signature validation to a validator as set by the party per signature hash. There is a default fallback validator for off-chain calls (checked via call from `tx.origin == address(0)`). This off-chain validator checks that the message is a plain text message (not EIP712) and that the signatory is a member of the party.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Link T-2997
