### PR TITLE
refactor(renderer): metadata tweaks

### DIFF
--- a/contracts/renderers/PartyNFTRenderer.sol
+++ b/contracts/renderers/PartyNFTRenderer.sol
@@ -117,14 +117,10 @@ contract PartyNFTRenderer is RendererBase {
                         bytes(metadata.image).length == 0 ? image : metadata.image,
                         // Determine which banner to render.
                         bytes(metadata.banner).length == 0
-                            ? // No custom banner.
-                            bytes(metadata.image).length == 0
-                                ? // If there is also no custom image, use the default Party banner.
-                                string.concat('", "banner":"', banner)
-                                : // If there is a custom image, do not include banner in metadata.
-                                ""
-                            : // Custom banner, use it.
-                            string.concat('", "banner":"', metadata.banner),
+                            ? bytes(metadata.image).length == 0 // No custom banner and no custom image, use the default Party banner.
+                                ? string.concat('", "banner":"', banner) // No custom banner but custom image, do not include banner in metadata.
+                                : ""
+                            : string.concat('", "banner":"', metadata.banner), // Custom banner, use it.
                         '"}'
                     )
                 )

--- a/contracts/renderers/PartyNFTRenderer.sol
+++ b/contracts/renderers/PartyNFTRenderer.sol
@@ -115,9 +115,16 @@ contract PartyNFTRenderer is RendererBase {
                             : metadata.collectionExternalURL,
                         '", "image":"',
                         bytes(metadata.image).length == 0 ? image : metadata.image,
-                        '", "banner":"',
-                        bytes(metadata.banner).length == 0 ? banner : metadata.banner,
-                        '"}'
+                        // Determine which banner to render.
+                        bytes(metadata.banner).length == 0 ?
+                            // No custom banner.
+                            bytes(metadata.image).length == 0 ?
+                                // If there is also no custom image, use the default Party banner.
+                                string.concat('", "banner":"', banner) :
+                                // If there is a custom image, do not include banner in metadata.
+                                "" :
+                            // Custom banner, use it.
+                            string.concat('", "banner":"', metadata.banner),
                     )
                 )
             );
@@ -188,7 +195,7 @@ contract PartyNFTRenderer is RendererBase {
                             : string.concat(
                                 metadata.description,
                                 // Append default description.
-                                " ",
+                                "\n\n",
                                 generateDescription(
                                     PartyGovernanceNFT(address(this)).name(),
                                     tokenId

--- a/contracts/renderers/PartyNFTRenderer.sol
+++ b/contracts/renderers/PartyNFTRenderer.sol
@@ -116,15 +116,16 @@ contract PartyNFTRenderer is RendererBase {
                         '", "image":"',
                         bytes(metadata.image).length == 0 ? image : metadata.image,
                         // Determine which banner to render.
-                        bytes(metadata.banner).length == 0 ?
-                            // No custom banner.
-                            bytes(metadata.image).length == 0 ?
-                                // If there is also no custom image, use the default Party banner.
-                                string.concat('", "banner":"', banner) :
-                                // If there is a custom image, do not include banner in metadata.
-                                "" :
-                            // Custom banner, use it.
+                        bytes(metadata.banner).length == 0
+                            ? // No custom banner.
+                            bytes(metadata.image).length == 0
+                                ? // If there is also no custom image, use the default Party banner.
+                                string.concat('", "banner":"', banner)
+                                : // If there is a custom image, do not include banner in metadata.
+                                ""
+                            : // Custom banner, use it.
                             string.concat('", "banner":"', metadata.banner),
+                        '"}'
                     )
                 )
             );


### PR DESCRIPTION
Link T-3190

Example of updated custom description (default appended description now separated by newlines):
```
Hey. I'm a placeholder custom description. Just minding my own business.

This membership represents 10% voting power in Party of the Living Dead. Head to https://party.app/party/0x4da6feb8f32416e7ad1e0795742cd64d5b8b8836 to view the Party's latest activity.
```

Example of metadata when custom banner is set (should always use custom banner if set):
```JSON
{"name":"CUSTOM_COLLECTION_NAME", "description":"CUSTOM_COLLECTION_DESCRIPTION", "external_url":"CUSTOM_COLLECTION_EXTERNAL_URL", "image":"CUSTOM_IMAGE", "banner":"CUSTOM_BANNER"}
```

Example of metadata when NO custom banner and custom image is set (should not include banner attribute, blank):
```JSON
{"name":"CUSTOM_COLLECTION_NAME", "description":"CUSTOM_COLLECTION_DESCRIPTION", "external_url":"CUSTOM_COLLECTION_EXTERNAL_URL", "image":"CUSTOM_IMAGE"}
```

Example of metadata when NO custom banner and default image is set (should use default Party banner):
```JSON
{"name":"CUSTOM_COLLECTION_NAME", "description":"CUSTOM_COLLECTION_DESCRIPTION", "external_url":"CUSTOM_COLLECTION_EXTERNAL_URL", "image":"ipfs://QmZKE4XkPvU7Z8CdgK2Cn7gLQ4t8CDkkfnR1j5bZ2AfRJu", "banner":"ipfs://QmTKCqLUQJt3VxGuUqLMj1jcCRRsaZwY4k757Wb7YPzmH2"}
```