### PR TITLE
chore: emit events on setting globals

### DIFF
--- a/contracts/globals/Globals.sol
+++ b/contracts/globals/Globals.sol
@@ -17,6 +17,11 @@ contract Globals is IGlobals, Multicall {
     error OnlyPendingMultiSigError();
     error InvalidBooleanValueError(uint256 key, uint256 value);
 
+    /// @notice Emitted when a value is set.
+    event ValueSet(uint256 key, bytes32 oldValue, bytes32 newValue);
+    /// @notice Emitted when includes is set.
+    event IncludesSet(uint256 key, bytes32 value, bool oldIsIncluded, bool newIsIncluded);
+
     modifier onlyMultisig() {
         if (msg.sender != multiSig) {
             revert OnlyMultiSigError();
@@ -81,30 +86,42 @@ contract Globals is IGlobals, Multicall {
     }
 
     function setBytes32(uint256 key, bytes32 value) external onlyMultisig {
+        emit ValueSet(key, _wordValues[key], value);
         _wordValues[key] = value;
     }
 
     function setUint256(uint256 key, uint256 value) external onlyMultisig {
+        emit ValueSet(key, _wordValues[key], bytes32(value));
         _wordValues[key] = bytes32(value);
     }
 
     function setBool(uint256 key, bool value) external onlyMultisig {
+        emit ValueSet(key, _wordValues[key], value ? bytes32(uint256(1)) : bytes32(0));
         _wordValues[key] = value ? bytes32(uint256(1)) : bytes32(0);
     }
 
     function setAddress(uint256 key, address value) external onlyMultisig {
+        emit ValueSet(key, _wordValues[key], bytes32(uint256(uint160(value))));
         _wordValues[key] = bytes32(uint256(uint160(value)));
     }
 
     function setIncludesBytes32(uint256 key, bytes32 value, bool isIncluded) external onlyMultisig {
+        emit IncludesSet(key, value, _includedWordValues[key][value], isIncluded);
         _includedWordValues[key][value] = isIncluded;
     }
 
     function setIncludesUint256(uint256 key, uint256 value, bool isIncluded) external onlyMultisig {
+        emit IncludesSet(key, bytes32(value), _includedWordValues[key][bytes32(value)], isIncluded);
         _includedWordValues[key][bytes32(value)] = isIncluded;
     }
 
     function setIncludesAddress(uint256 key, address value, bool isIncluded) external onlyMultisig {
+        emit IncludesSet(
+            key,
+            bytes32(uint256(uint160(value))),
+            _includedWordValues[key][bytes32(uint256(uint160(value)))],
+            isIncluded
+        );
         _includedWordValues[key][bytes32(uint256(uint160(value)))] = isIncluded;
     }
 }

--- a/contracts/globals/Globals.sol
+++ b/contracts/globals/Globals.sol
@@ -21,6 +21,10 @@ contract Globals is IGlobals, Multicall {
     event ValueSet(uint256 key, bytes32 oldValue, bytes32 newValue);
     /// @notice Emitted when includes is set.
     event IncludesSet(uint256 key, bytes32 value, bool oldIsIncluded, bool newIsIncluded);
+    /// @notice Emitted when the multisig is transferred and now pending.
+    event MultiSigTransferred(address indexed multisig, address indexed pendingMultiSig);
+    /// @notice Emitted when the multisig transfer is accepted.
+    event MultiSigAccepted(address indexed oldMultiSig, address indexed newMultiSig);
 
     modifier onlyMultisig() {
         if (msg.sender != multiSig) {
@@ -41,11 +45,14 @@ contract Globals is IGlobals, Multicall {
     }
 
     function transferMultiSig(address newMultiSig) external onlyMultisig {
+        emit MultiSigTransferred(multiSig, newMultiSig);
         pendingMultiSig = newMultiSig;
     }
 
     function acceptMultiSig() external onlyPendingMultisig {
-        multiSig = pendingMultiSig;
+        address newMultiSig = pendingMultiSig;
+        emit MultiSigAccepted(multiSig, newMultiSig);
+        multiSig = newMultiSig;
         delete pendingMultiSig;
     }
 

--- a/contracts/globals/Globals.sol
+++ b/contracts/globals/Globals.sol
@@ -22,9 +22,12 @@ contract Globals is IGlobals, Multicall {
     /// @notice Emitted when includes is set.
     event IncludesSet(uint256 key, bytes32 value, bool oldIsIncluded, bool newIsIncluded);
     /// @notice Emitted when the multisig is transferred and now pending.
-    event MultiSigTransferred(address indexed multisig, address indexed pendingMultiSig);
+    event PendingMultiSigSet(
+        address indexed oldPendingMultiSig,
+        address indexed newPendingMultiSig
+    );
     /// @notice Emitted when the multisig transfer is accepted.
-    event MultiSigAccepted(address indexed oldMultiSig, address indexed newMultiSig);
+    event MultiSigSet(address indexed oldMultiSig, address indexed newMultiSig);
 
     modifier onlyMultisig() {
         if (msg.sender != multiSig) {
@@ -45,15 +48,16 @@ contract Globals is IGlobals, Multicall {
     }
 
     function transferMultiSig(address newMultiSig) external onlyMultisig {
-        emit MultiSigTransferred(multiSig, newMultiSig);
+        emit PendingMultiSigSet(pendingMultiSig, newMultiSig);
         pendingMultiSig = newMultiSig;
     }
 
     function acceptMultiSig() external onlyPendingMultisig {
         address newMultiSig = pendingMultiSig;
-        emit MultiSigAccepted(multiSig, newMultiSig);
+        emit MultiSigSet(multiSig, newMultiSig);
         multiSig = newMultiSig;
         delete pendingMultiSig;
+        emit PendingMultiSigSet(newMultiSig, address(0));
     }
 
     function getBytes32(uint256 key) external view returns (bytes32) {

--- a/test/globals/Globals.t.sol
+++ b/test/globals/Globals.t.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8;
+
+import "contracts/globals/Globals.sol";
+import "../TestUtils.sol";
+
+contract GlobalsTest is TestUtils {
+    event ValueSet(uint256 key, bytes32 oldValue, bytes32 newValue);
+    event IncludesSet(uint256 key, bytes32 value, bool oldIsIncluded, bool newIsIncluded);
+    event MultiSigTransferred(address indexed multisig, address indexed pendingMultiSig);
+    event MultiSigAccepted(address indexed oldMultiSig, address indexed newMultiSig);
+
+    Globals globals = new Globals(address(this));
+
+    function test_transferAndAccept_multisig() public {
+        address payable newMultisig = _randomAddress();
+
+        vm.expectEmit(true, true, true, true);
+        emit MultiSigTransferred(address(this), newMultisig);
+        globals.transferMultiSig(newMultisig);
+
+        assertEq(globals.pendingMultiSig(), newMultisig);
+        assertEq(globals.multiSig(), address(this));
+
+        vm.prank(newMultisig);
+        vm.expectEmit(true, true, true, true);
+        emit MultiSigAccepted(address(this), newMultisig);
+        globals.acceptMultiSig();
+
+        assertEq(globals.multiSig(), newMultisig);
+        assertEq(globals.pendingMultiSig(), address(0));
+    }
+
+    function test_transferMultisig_notMultisig() public {
+        address payable notMultisig = _randomAddress();
+
+        vm.prank(notMultisig);
+        vm.expectRevert(Globals.OnlyMultiSigError.selector);
+        globals.transferMultiSig(notMultisig);
+    }
+
+    function test_acceptMultisig_notPendingMultisig() public {
+        address payable notPendingMultisig = _randomAddress();
+
+        vm.prank(notPendingMultisig);
+        vm.expectRevert(Globals.OnlyPendingMultiSigError.selector);
+        globals.acceptMultiSig();
+    }
+
+    function test_setAndGetBytes32_works() public {
+        uint256 key = _randomUint256();
+        bytes32 value = _randomBytes32();
+
+        assertEq(globals.getBytes32(key), bytes32(0));
+
+        vm.expectEmit(true, true, true, true);
+        emit ValueSet(key, bytes32(0), value);
+        globals.setBytes32(key, value);
+
+        assertEq(globals.getBytes32(key), value);
+    }
+
+    function test_setBytes32_onlyMultisig() public {
+        uint256 key = _randomUint256();
+        bytes32 value = _randomBytes32();
+
+        vm.prank(_randomAddress());
+        vm.expectRevert(Globals.OnlyMultiSigError.selector);
+        globals.setBytes32(key, value);
+    }
+
+    function test_setAndGetUint256_works() public {
+        uint256 key = _randomUint256();
+        uint256 value = _randomUint256();
+
+        assertEq(globals.getUint256(key), 0);
+
+        vm.expectEmit(true, true, true, true);
+        emit ValueSet(key, bytes32(0), bytes32(value));
+        globals.setUint256(key, value);
+
+        assertEq(globals.getUint256(key), value);
+    }
+
+    function test_setUint256_onlyMultisig() public {
+        uint256 key = _randomUint256();
+        uint256 value = _randomUint256();
+
+        vm.prank(_randomAddress());
+        vm.expectRevert(Globals.OnlyMultiSigError.selector);
+        globals.setUint256(key, value);
+    }
+
+    function test_setAndGetBool_works() public {
+        uint256 key = _randomUint256();
+
+        assertEq(globals.getBool(key), false);
+
+        vm.expectEmit(true, true, true, true);
+        emit ValueSet(key, bytes32(0), bytes32(uint256(1)));
+        globals.setBool(key, true);
+
+        assertEq(globals.getBool(key), true);
+    }
+
+    function test_setAndGetAddress_works() public {
+        uint256 key = _randomUint256();
+        address value = _randomAddress();
+
+        assertEq(globals.getAddress(key), address(0));
+
+        vm.expectEmit(true, true, true, true);
+        emit ValueSet(key, bytes32(0), bytes32(uint256(uint160(value))));
+        globals.setAddress(key, value);
+
+        assertEq(globals.getAddress(key), value);
+    }
+
+    function test_setAddress_onlyMultisig() public {
+        uint256 key = _randomUint256();
+        address value = _randomAddress();
+
+        vm.prank(_randomAddress());
+        vm.expectRevert(Globals.OnlyMultiSigError.selector);
+        globals.setAddress(key, value);
+    }
+
+    function test_setAndGetIncludesBytes32_works() public {
+        uint256 key = _randomUint256();
+        bytes32 value = _randomBytes32();
+
+        assertEq(globals.getIncludesBytes32(key, value), false);
+
+        vm.expectEmit(true, true, true, true);
+        emit IncludesSet(key, value, false, true);
+        globals.setIncludesBytes32(key, value, true);
+
+        assertEq(globals.getIncludesBytes32(key, value), true);
+    }
+
+    function test_setIncludesBytes32_onlyMultisig() public {
+        uint256 key = _randomUint256();
+        bytes32 value = _randomBytes32();
+
+        vm.prank(_randomAddress());
+        vm.expectRevert(Globals.OnlyMultiSigError.selector);
+        globals.setIncludesBytes32(key, value, true);
+    }
+
+    function test_setAndGetIncludesUint256_works() public {
+        uint256 key = _randomUint256();
+        uint256 value = _randomUint256();
+
+        assertEq(globals.getIncludesUint256(key, value), false);
+
+        vm.expectEmit(true, true, true, true);
+        emit IncludesSet(key, bytes32(value), false, true);
+        globals.setIncludesUint256(key, value, true);
+
+        assertEq(globals.getIncludesUint256(key, value), true);
+    }
+
+    function test_setIncludesUint256_onlyMultisig() public {
+        uint256 key = _randomUint256();
+        uint256 value = _randomUint256();
+
+        vm.prank(_randomAddress());
+        vm.expectRevert(Globals.OnlyMultiSigError.selector);
+        globals.setIncludesUint256(key, value, true);
+    }
+
+    function test_setAndGetIncludesAddress_works() public {
+        uint256 key = _randomUint256();
+        address value = _randomAddress();
+
+        assertEq(globals.getIncludesAddress(key, value), false);
+
+        vm.expectEmit(true, true, true, true);
+        emit IncludesSet(key, bytes32(uint256(uint160(value))), false, true);
+        globals.setIncludesAddress(key, value, true);
+
+        assertEq(globals.getIncludesAddress(key, value), true);
+    }
+
+    function test_setIncludesAddress_onlyMultisig() public {
+        uint256 key = _randomUint256();
+        address value = _randomAddress();
+
+        vm.prank(_randomAddress());
+        vm.expectRevert(Globals.OnlyMultiSigError.selector);
+        globals.setIncludesAddress(key, value, true);
+    }
+}

--- a/test/globals/Globals.t.sol
+++ b/test/globals/Globals.t.sol
@@ -7,8 +7,8 @@ import "../TestUtils.sol";
 contract GlobalsTest is TestUtils {
     event ValueSet(uint256 key, bytes32 oldValue, bytes32 newValue);
     event IncludesSet(uint256 key, bytes32 value, bool oldIsIncluded, bool newIsIncluded);
-    event MultiSigTransferred(address indexed multisig, address indexed pendingMultiSig);
-    event MultiSigAccepted(address indexed oldMultiSig, address indexed newMultiSig);
+    event PendingMultiSigSet(address indexed oldPendingMultiSig, address indexed pendingMultiSig);
+    event MultiSigSet(address indexed oldMultiSig, address indexed newMultiSig);
 
     Globals globals = new Globals(address(this));
 
@@ -16,7 +16,7 @@ contract GlobalsTest is TestUtils {
         address payable newMultisig = _randomAddress();
 
         vm.expectEmit(true, true, true, true);
-        emit MultiSigTransferred(address(this), newMultisig);
+        emit PendingMultiSigSet(address(0), newMultisig);
         globals.transferMultiSig(newMultisig);
 
         assertEq(globals.pendingMultiSig(), newMultisig);
@@ -24,7 +24,7 @@ contract GlobalsTest is TestUtils {
 
         vm.prank(newMultisig);
         vm.expectEmit(true, true, true, true);
-        emit MultiSigAccepted(address(this), newMultisig);
+        emit MultiSigSet(address(this), newMultisig);
         globals.acceptMultiSig();
 
         assertEq(globals.multiSig(), newMultisig);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Upon setting new values in globals, it is not easy to see what the old value. This is important in case we have issues with the new value and have to revert.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
By emitting the old and new value, we can easily see the new and old values for keys.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Link T-3295
