### PR TITLE
chore: add line break custom description

### DIFF
--- a/contracts/renderers/PartyNFTRenderer.sol
+++ b/contracts/renderers/PartyNFTRenderer.sol
@@ -200,7 +200,7 @@ contract PartyNFTRenderer is RendererBase {
                             ? generateDescription(PartyGovernanceNFT(address(this)).name(), tokenId)
                             : string.concat(
                                 metadata.description,
-                                " ",
+                                "\\n\\n",
                                 // Append default description.
                                 generateDescription(
                                     PartyGovernanceNFT(address(this)).name(),


### PR DESCRIPTION
Bring back the desired line break for custom metadata descriptions.

Link T-3302