### PR TITLE
mitigations: Dynamic party card prices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,5 +116,3 @@ jobs:
         run: forge install
       - name: Check contract deployable mainnet
         run: "node js/contracts-deployable.js --via-ir --optimize --optimizer-runs 0"
-      - name: Check contracts deployable base
-        run: "node js/contracts-deployable.js --via-ir --optimize --optimizer-runs 0 --evm-version paris"

--- a/contracts/authorities/BondingCurveAuthority.sol
+++ b/contracts/authorities/BondingCurveAuthority.sol
@@ -347,11 +347,7 @@ contract BondingCurveAuthority {
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
         uint256 creatorFee = (bondingCurvePrice * (partyInfo.creatorFeeOn ? creatorFeeBps : 0)) /
             BPS;
-
         uint256 sellerProceeds = bondingCurvePrice - partyDaoFee - treasuryFee - creatorFee;
-        if (sellerProceeds < minProceeds) {
-            revert ExcessSlippage();
-        }
 
         partyInfos[party].supply = partyInfo.supply - amount;
 
@@ -385,10 +381,15 @@ contract BondingCurveAuthority {
             }
         }
 
+        if (sellerProceeds < minProceeds) {
+            revert ExcessSlippage();
+        }
+
         (success, ) = msg.sender.call{ value: sellerProceeds }("");
         if (!success) {
             revert EthTransferFailed();
         }
+
         partyDaoFeeClaimable += partyDaoFee.safeCastUint256ToUint96();
 
         emit PartyCardsSold(

--- a/contracts/authorities/BondingCurveAuthority.sol
+++ b/contracts/authorities/BondingCurveAuthority.sol
@@ -6,6 +6,7 @@ import { PartyFactory } from "../party/PartyFactory.sol";
 import { IERC721 } from "../tokens/IERC721.sol";
 import { MetadataProvider } from "../renderers/MetadataProvider.sol";
 import { LibSafeCast } from "contracts/utils/LibSafeCast.sol";
+import { ProposalStorage } from "contracts/proposals/ProposalStorage.sol";
 
 contract BondingCurveAuthority {
     using LibSafeCast for uint256;
@@ -23,6 +24,7 @@ contract BondingCurveAuthority {
     error ExcessSlippage();
     error AddAuthorityProposalNotSupported();
     error SellZeroPartyCards();
+    error DistributionsNotSupported();
 
     event TreasuryFeeUpdated(uint16 previousTreasuryFee, uint16 newTreasuryFee);
     event PartyDaoFeeUpdated(uint16 previousPartyDaoFee, uint16 newPartyDaoFee);
@@ -228,6 +230,13 @@ contract BondingCurveAuthority {
 
         if (partyOpts.proposalEngine.enableAddAuthorityProposal) {
             revert AddAuthorityProposalNotSupported();
+        }
+
+        if (
+            partyOpts.proposalEngine.distributionsConfig !=
+            ProposalStorage.DistributionsConfig.NotAllowed
+        ) {
+            revert DistributionsNotSupported();
         }
     }
 

--- a/contracts/authorities/BondingCurveAuthority.sol
+++ b/contracts/authorities/BondingCurveAuthority.sol
@@ -300,7 +300,7 @@ contract BondingCurveAuthority {
             party,
             msg.sender,
             tokenIds,
-            msg.value,
+            totalCost,
             partyDaoFee,
             treasuryFee,
             creatorFee
@@ -412,15 +412,12 @@ contract BondingCurveAuthority {
             partyInfo.a,
             partyInfo.b
         );
+        uint256 partyDaoFee = (bondingCurvePrice * partyDaoFeeBps) / BPS;
+        uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
+        uint256 creatorFee = (bondingCurvePrice * (partyInfo.creatorFeeOn ? creatorFeeBps : 0)) /
+            BPS;
         // Note: 1 is subtracted for each NFT to account for rounding errors
-        return
-            (bondingCurvePrice *
-                (BPS -
-                    partyDaoFeeBps -
-                    treasuryFeeBps -
-                    (partyInfo.creatorFeeOn ? creatorFeeBps : 0))) /
-            BPS -
-            amount;
+        return bondingCurvePrice - partyDaoFee - treasuryFee - creatorFee - amount;
     }
 
     /**
@@ -458,9 +455,10 @@ contract BondingCurveAuthority {
         bool creatorFeeOn
     ) public view returns (uint256) {
         uint256 bondingCurvePrice = _getBondingCurvePrice(supply, amount, a, b);
-        return
-            (bondingCurvePrice *
-                (BPS + partyDaoFeeBps + treasuryFeeBps + (creatorFeeOn ? creatorFeeBps : 0))) / BPS;
+        uint256 partyDaoFee = (bondingCurvePrice * partyDaoFeeBps) / BPS;
+        uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
+        uint256 creatorFee = (bondingCurvePrice * (creatorFeeOn ? creatorFeeBps : 0)) / BPS;
+        return bondingCurvePrice + partyDaoFee + treasuryFee + creatorFee;
     }
 
     /**

--- a/contracts/authorities/BondingCurveAuthority.sol
+++ b/contracts/authorities/BondingCurveAuthority.sol
@@ -25,6 +25,7 @@ contract BondingCurveAuthority {
     error AddAuthorityProposalNotSupported();
     error SellZeroPartyCards();
     error DistributionsNotSupported();
+    error NeedAtLeastOneHost();
 
     event TreasuryFeeUpdated(uint16 previousTreasuryFee, uint16 newTreasuryFee);
     event PartyDaoFeeUpdated(uint16 previousPartyDaoFee, uint16 newPartyDaoFee);
@@ -68,7 +69,7 @@ contract BondingCurveAuthority {
     uint16 private constant MAX_TREASURY_FEE = 1000; // 10%
     uint16 private constant MAX_PARTY_DAO_FEE = 250; // 2.5%
     /// @notice The minimum execution delay for party governance
-    uint40 private constant MIN_EXECUTION_DELAY = 1 seconds;
+    uint40 private constant MIN_EXECUTION_DELAY = 1 hours;
 
     /// @notice Struct containing options for creating a party
     struct BondingCurvePartyOptions {
@@ -220,7 +221,7 @@ contract BondingCurveAuthority {
         if (partyOpts.governance.totalVotingPower != 0) {
             revert InvalidTotalVotingPower();
         }
-        // Note: while the `executionDelay` is not enforced to be over 1 second,
+        // Note: while the `executionDelay` is not enforced to be over 1 hour,
         //       it is strongly recommended for it to be a long period
         //       (greater than 1 day). This prevents an attacker from buying cards,
         //       draining the party and then selling before a host can react.
@@ -237,6 +238,10 @@ contract BondingCurveAuthority {
             ProposalStorage.DistributionsConfig.NotAllowed
         ) {
             revert DistributionsNotSupported();
+        }
+
+        if (partyOpts.governance.hosts.length == 0) {
+            revert NeedAtLeastOneHost();
         }
     }
 

--- a/contracts/authorities/BondingCurveAuthority.sol
+++ b/contracts/authorities/BondingCurveAuthority.sol
@@ -280,7 +280,11 @@ contract BondingCurveAuthority {
 
         if (creatorFee != 0) {
             // Creator fee payment can fail
-            (bool creatorFeeSucceeded, ) = partyInfo.creator.call{ value: creatorFee }("");
+            // Gas limit is set to 100k to prevent consuming all gas
+            (bool creatorFeeSucceeded, ) = partyInfo.creator.call{
+                value: creatorFee,
+                gas: 100_000
+            }("");
             if (!creatorFeeSucceeded) {
                 totalCost -= creatorFee;
             }
@@ -371,7 +375,11 @@ contract BondingCurveAuthority {
 
         if (creatorFee != 0) {
             // Creator fee payment can fail
-            (bool creatorFeeSucceeded, ) = partyInfo.creator.call{ value: creatorFee }("");
+            // Gas limit is set to 100k to prevent consuming all gas
+            (bool creatorFeeSucceeded, ) = partyInfo.creator.call{
+                value: creatorFee,
+                gas: 100_000
+            }("");
             if (!creatorFeeSucceeded) {
                 sellerProceeds += creatorFee;
             }

--- a/contracts/authorities/BondingCurveAuthority.sol
+++ b/contracts/authorities/BondingCurveAuthority.sol
@@ -268,7 +268,8 @@ contract BondingCurveAuthority {
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
         uint256 creatorFee = (bondingCurvePrice * (partyInfo.creatorFeeOn ? creatorFeeBps : 0)) /
             BPS;
-        uint256 totalCost = bondingCurvePrice + partyDaoFee + treasuryFee + creatorFee;
+        // Note: 1 is added for each NFT to account for rounding errors
+        uint256 totalCost = bondingCurvePrice + partyDaoFee + treasuryFee + creatorFee + amount;
 
         partyInfos[party].supply = partyInfo.supply + amount;
 
@@ -343,12 +344,7 @@ contract BondingCurveAuthority {
         uint256 creatorFee = (bondingCurvePrice * (partyInfo.creatorFeeOn ? creatorFeeBps : 0)) /
             BPS;
 
-        // Note: 1 is subtracted for each NFT to account for rounding errors
-        uint256 sellerProceeds = bondingCurvePrice -
-            partyDaoFee -
-            treasuryFee -
-            creatorFee -
-            amount;
+        uint256 sellerProceeds = bondingCurvePrice - partyDaoFee - treasuryFee - creatorFee;
         if (sellerProceeds < minProceeds) {
             revert ExcessSlippage();
         }
@@ -416,8 +412,7 @@ contract BondingCurveAuthority {
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
         uint256 creatorFee = (bondingCurvePrice * (partyInfo.creatorFeeOn ? creatorFeeBps : 0)) /
             BPS;
-        // Note: 1 is subtracted for each NFT to account for rounding errors
-        return bondingCurvePrice - partyDaoFee - treasuryFee - creatorFee - amount;
+        return bondingCurvePrice - partyDaoFee - treasuryFee - creatorFee;
     }
 
     /**
@@ -458,7 +453,8 @@ contract BondingCurveAuthority {
         uint256 partyDaoFee = (bondingCurvePrice * partyDaoFeeBps) / BPS;
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
         uint256 creatorFee = (bondingCurvePrice * (creatorFeeOn ? creatorFeeBps : 0)) / BPS;
-        return bondingCurvePrice + partyDaoFee + treasuryFee + creatorFee;
+        // Note: 1 is added for each NFT to account for rounding errors
+        return bondingCurvePrice + partyDaoFee + treasuryFee + creatorFee + amount;
     }
 
     /**

--- a/contracts/authorities/BondingCurveAuthority.sol
+++ b/contracts/authorities/BondingCurveAuthority.sol
@@ -22,6 +22,7 @@ contract BondingCurveAuthority {
     error EthTransferFailed();
     error ExcessSlippage();
     error AddAuthorityProposalNotSupported();
+    error SellZeroPartyCards();
 
     event TreasuryFeeUpdated(uint16 previousTreasuryFee, uint16 newTreasuryFee);
     event PartyDaoFeeUpdated(uint16 previousPartyDaoFee, uint16 newPartyDaoFee);
@@ -311,6 +312,10 @@ contract BondingCurveAuthority {
      * @param tokenIds The token ids to sell
      */
     function sellPartyCards(Party party, uint256[] memory tokenIds, uint256 minProceeds) external {
+        if (tokenIds.length == 0) {
+            revert SellZeroPartyCards();
+        }
+
         PartyInfo memory partyInfo = partyInfos[party];
 
         if (partyInfo.creator == address(0)) {

--- a/contracts/party/PartyGovernance.sol
+++ b/contracts/party/PartyGovernance.sol
@@ -498,7 +498,10 @@ abstract contract PartyGovernance is
             // Must not require a vote to create a distribution, otherwise
             // distributions can only be created through a distribution
             // proposal.
-            if (_getSharedProposalStorage().opts.distributionsRequireVote) {
+            if (
+                _getSharedProposalStorage().opts.distributionsConfig !=
+                DistributionsConfig.AllowedWithoutVote
+            ) {
                 revert DistributionsRequireVoteError();
             }
             // Must be an active member.
@@ -1115,14 +1118,6 @@ abstract contract PartyGovernance is
         uint8 numHostsAccepted
     ) private pure returns (bool) {
         return snapshotNumHosts > 0 && snapshotNumHosts == numHostsAccepted;
-    }
-
-    function _areVotesPassing(
-        uint96 voteCount,
-        uint96 totalVotingPower,
-        uint16 passThresholdBps
-    ) private pure returns (bool) {
-        return (uint256(voteCount) * 1e4) / uint256(totalVotingPower) >= uint256(passThresholdBps);
     }
 
     function _setPreciousList(

--- a/contracts/party/PartyGovernanceNFT.sol
+++ b/contracts/party/PartyGovernanceNFT.sol
@@ -99,7 +99,7 @@ abstract contract PartyGovernanceNFT is PartyGovernance, ERC721, IERC2981 {
         name = name_;
         symbol = symbol_;
         if (rageQuitTimestamp_ != 0) {
-            if (!proposalEngineOpts.distributionsRequireVote) {
+            if (proposalEngineOpts.distributionsConfig == DistributionsConfig.AllowedWithoutVote) {
                 revert CannotEnableRageQuitIfNotDistributionsRequireVoteError();
             }
 
@@ -346,8 +346,10 @@ abstract contract PartyGovernanceNFT is PartyGovernance, ERC721, IERC2981 {
         }
 
         // Prevent enabling ragequit if distributions can be created without a vote.
-        if (!_getSharedProposalStorage().opts.distributionsRequireVote)
-            revert CannotEnableRageQuitIfNotDistributionsRequireVoteError();
+        if (
+            _getSharedProposalStorage().opts.distributionsConfig ==
+            DistributionsConfig.AllowedWithoutVote
+        ) revert CannotEnableRageQuitIfNotDistributionsRequireVoteError();
 
         uint40 oldRageQuitTimestamp = rageQuitTimestamp;
 

--- a/contracts/proposals/ProposalExecutionEngine.sol
+++ b/contracts/proposals/ProposalExecutionEngine.sol
@@ -263,7 +263,10 @@ contract ProposalExecutionEngine is
                 _getSharedProposalStorage().opts.allowArbCallsToSpendPartyEth
             );
         } else if (pt == ProposalType.Distribute) {
-            if (!_getSharedProposalStorage().opts.distributionsRequireVote) {
+            if (
+                _getSharedProposalStorage().opts.distributionsConfig !=
+                DistributionsConfig.AllowedWithVote
+            ) {
                 revert ProposalDisabled(pt);
             }
 

--- a/contracts/proposals/ProposalStorage.sol
+++ b/contracts/proposals/ProposalStorage.sol
@@ -24,6 +24,12 @@ abstract contract ProposalStorage {
         uint96 totalVotingPower;
     }
 
+    enum DistributionsConfig {
+        AllowedWithoutVote,
+        AllowedWithVote,
+        NotAllowed
+    }
+
     struct ProposalEngineOpts {
         // Whether the party can add new authorities with the add authority proposal.
         bool enableAddAuthorityProposal;
@@ -32,8 +38,8 @@ abstract contract ProposalStorage {
         bool allowArbCallsToSpendPartyEth;
         // Whether operators can be used.
         bool allowOperators;
-        // Whether distributions require a vote or can be executed by any active member.
-        bool distributionsRequireVote;
+        // Distributions config for the party.
+        DistributionsConfig distributionsConfig;
     }
 
     uint256 internal constant PROPOSAL_FLAG_UNANIMOUS = 0x1;

--- a/test/authorities/BondingCurveAuthority.t.sol
+++ b/test/authorities/BondingCurveAuthority.t.sol
@@ -214,6 +214,22 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
         );
     }
 
+    function test_createParty_revertNeedAtLeastOneHost() external {
+        opts.governance.hosts = new address[](0);
+        vm.expectRevert(BondingCurveAuthority.NeedAtLeastOneHost.selector);
+        authority.createParty(
+            BondingCurveAuthority.BondingCurvePartyOptions({
+                partyFactory: partyFactory,
+                partyImpl: partyImpl,
+                opts: opts,
+                creatorFeeOn: true,
+                a: 50_000,
+                b: uint80(0.001 ether)
+            }),
+            1
+        );
+    }
+
     function test_createParty_moreThanOnePartyCard() public {
         (Party party, address payable creator, ) = _createParty(5, true);
 

--- a/test/authorities/BondingCurveAuthority.t.sol
+++ b/test/authorities/BondingCurveAuthority.t.sol
@@ -605,6 +605,11 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
         authority.sellPartyCards(Party(payable(_randomAddress())), new uint256[](1), 0);
     }
 
+    function test_sellPartyCards_cantSellZero() public {
+        vm.expectRevert(BondingCurveAuthority.SellZeroPartyCards.selector);
+        authority.sellPartyCards(Party(payable(_randomAddress())), new uint256[](0), 0);
+    }
+
     function test_sellPartyCards_isApprovedForAll() public {
         (Party party, , , address buyer, ) = test_buyPartyCards_works();
 

--- a/test/authorities/BondingCurveAuthority.t.sol
+++ b/test/authorities/BondingCurveAuthority.t.sol
@@ -157,7 +157,7 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
         assertEq(
             address(authority).balance,
             // Creator fee is held in BondingCurveAuthority until claimed.
-            expectedBondingCurvePrice + expectedPartyDaoFee
+            expectedBondingCurvePrice + expectedPartyDaoFee + 1
         );
     }
 
@@ -278,7 +278,8 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
         uint256 initialPrice = 0.001 ether;
         initialPrice =
             (initialPrice * (1e4 + authority.treasuryFeeBps() + authority.partyDaoFeeBps())) /
-            1e4;
+            1e4 +
+            1;
 
         vm.deal(creator, initialPrice);
         vm.prank(creator);
@@ -362,7 +363,7 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
 
         uint256 expectedPriceToBuy = authority.getPriceToBuy(party, 10);
         expectedBondingCurvePrice =
-            (expectedPriceToBuy * 1e4) /
+            ((expectedPriceToBuy - 10) * 1e4) /
             (1e4 + TREASURY_FEE_BPS + PARTY_DAO_FEE_BPS + CREATOR_FEE_BPS);
         uint256 expectedPartyDaoFee = (expectedBondingCurvePrice * PARTY_DAO_FEE_BPS) / 1e4;
         uint256 expectedTreasuryFee = (expectedBondingCurvePrice * TREASURY_FEE_BPS) / 1e4;
@@ -408,7 +409,7 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
         assertEq(
             address(authority).balance - beforeAuthorityBalance,
             // Creator fee is held in BondingCurveAuthority until claimed.
-            expectedBondingCurvePrice + expectedPartyDaoFee
+            expectedBondingCurvePrice + expectedPartyDaoFee + 10
         );
         assertEq(address(party).balance - beforePartyBalance, expectedTreasuryFee);
         assertEq(creator.balance - beforeCreatorBalance, expectedCreatorFee);
@@ -530,7 +531,7 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
 
         uint256 expectedSaleProceeds = authority.getSaleProceeds(party, 10);
         expectedBondingCurvePrice =
-            ((expectedSaleProceeds + tokenIds.length) * 1e4) /
+            (expectedSaleProceeds * 1e4) /
             (1e4 - TREASURY_FEE_BPS - PARTY_DAO_FEE_BPS - CREATOR_FEE_BPS);
         uint256 expectedPartyDaoFee = (expectedBondingCurvePrice * PARTY_DAO_FEE_BPS) / 1e4;
         uint256 expectedTreasuryFee = (expectedBondingCurvePrice * TREASURY_FEE_BPS) / 1e4;
@@ -786,7 +787,7 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
         vm.prank(globalDaoWalletAddress);
         authority.claimPartyDaoFees();
 
-        assertEq(address(authority).balance, expectedBondingCurvePrice);
+        assertEq(address(authority).balance, expectedBondingCurvePrice + 1);
         assertEq(globalDaoWalletAddress.balance, expectedPartyDaoFee);
     }
 

--- a/test/crowdfund/CrowdfundFactory.t.sol
+++ b/test/crowdfund/CrowdfundFactory.t.sol
@@ -14,6 +14,7 @@ import "./MockMarketWrapper.sol";
 import "contracts/globals/Globals.sol";
 import "contracts/globals/LibGlobals.sol";
 import "contracts/renderers/MetadataRegistry.sol";
+import { ProposalStorage } from "contracts/proposals/ProposalStorage.sol";
 import "contracts/renderers/MetadataProvider.sol";
 import { FixedPointMathLib } from "solmate/utils/FixedPointMathLib.sol";
 import { LibSafeCast } from "contracts/utils/LibSafeCast.sol";
@@ -141,7 +142,7 @@ contract CrowdfundFactoryTest is Test, TestUtils {
                     enableAddAuthorityProposal: true,
                     allowArbCallsToSpendPartyEth: true,
                     allowOperators: true,
-                    distributionsRequireVote: true
+                    distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
                 })
             });
 
@@ -219,7 +220,7 @@ contract CrowdfundFactoryTest is Test, TestUtils {
                     enableAddAuthorityProposal: true,
                     allowArbCallsToSpendPartyEth: true,
                     allowOperators: true,
-                    distributionsRequireVote: true
+                    distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
                 })
             });
 
@@ -422,7 +423,7 @@ contract CrowdfundFactoryTest is Test, TestUtils {
                 enableAddAuthorityProposal: true,
                 allowArbCallsToSpendPartyEth: true,
                 allowOperators: true,
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         });
 
@@ -495,7 +496,7 @@ contract CrowdfundFactoryTest is Test, TestUtils {
                     enableAddAuthorityProposal: true,
                     allowArbCallsToSpendPartyEth: true,
                     allowOperators: true,
-                    distributionsRequireVote: true
+                    distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
                 })
             });
 
@@ -566,7 +567,7 @@ contract CrowdfundFactoryTest is Test, TestUtils {
                     enableAddAuthorityProposal: true,
                     allowArbCallsToSpendPartyEth: true,
                     allowOperators: true,
-                    distributionsRequireVote: true
+                    distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
                 })
             });
 
@@ -638,7 +639,7 @@ contract CrowdfundFactoryTest is Test, TestUtils {
                 enableAddAuthorityProposal: true,
                 allowArbCallsToSpendPartyEth: true,
                 allowOperators: true,
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             }),
             preciousTokens: new IERC721[](0),
             preciousTokenIds: new uint256[](0),
@@ -714,7 +715,7 @@ contract CrowdfundFactoryTest is Test, TestUtils {
                 enableAddAuthorityProposal: true,
                 allowArbCallsToSpendPartyEth: true,
                 allowOperators: true,
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             }),
             preciousTokens: new IERC721[](0),
             preciousTokenIds: new uint256[](0),
@@ -804,7 +805,7 @@ contract CrowdfundFactoryTest is Test, TestUtils {
                 enableAddAuthorityProposal: true,
                 allowArbCallsToSpendPartyEth: true,
                 allowOperators: true,
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             }),
             preciousTokens: new IERC721[](0),
             preciousTokenIds: new uint256[](0),
@@ -870,7 +871,7 @@ contract CrowdfundFactoryTest is Test, TestUtils {
                 enableAddAuthorityProposal: true,
                 allowArbCallsToSpendPartyEth: true,
                 allowOperators: true,
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             }),
             preciousTokens: new IERC721[](0),
             preciousTokenIds: new uint256[](0),

--- a/test/crowdfund/InitialETHCrowdfund.t.sol
+++ b/test/crowdfund/InitialETHCrowdfund.t.sol
@@ -1748,7 +1748,7 @@ contract InitialETHCrowdfundTest is InitialETHCrowdfundTestBase {
                 enableAddAuthorityProposal: true,
                 allowArbCallsToSpendPartyEth: true,
                 allowOperators: true,
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             }),
             preciousTokens: new IERC721[](0),
             preciousTokenIds: new uint256[](0),

--- a/test/party/PartyFactory.t.sol
+++ b/test/party/PartyFactory.t.sol
@@ -82,7 +82,7 @@ contract PartyFactoryTest is Test, TestUtils {
                 enableAddAuthorityProposal: true,
                 allowArbCallsToSpendPartyEth: true,
                 allowOperators: true,
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         });
         uint40 rageQuitTimestamp = uint40(block.timestamp + 30 days);
@@ -111,7 +111,10 @@ contract PartyFactoryTest is Test, TestUtils {
             .getProposalEngineOpts();
         assertEq(proposalEngineOpts.allowArbCallsToSpendPartyEth, true);
         assertEq(proposalEngineOpts.allowOperators, true);
-        assertEq(proposalEngineOpts.distributionsRequireVote, true);
+        assertEq(
+            uint8(proposalEngineOpts.distributionsConfig),
+            uint8(ProposalStorage.DistributionsConfig.AllowedWithVote)
+        );
         assertEq(party.preciousListHash(), _hashPreciousList(preciousTokens, preciousTokenIds));
     }
 
@@ -135,7 +138,7 @@ contract PartyFactoryTest is Test, TestUtils {
                 enableAddAuthorityProposal: true,
                 allowArbCallsToSpendPartyEth: true,
                 allowOperators: true,
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         });
         bytes memory customMetadata = abi.encodePacked(_randomBytes32());
@@ -168,7 +171,10 @@ contract PartyFactoryTest is Test, TestUtils {
             .getProposalEngineOpts();
         assertEq(proposalEngineOpts.allowArbCallsToSpendPartyEth, true);
         assertEq(proposalEngineOpts.allowOperators, true);
-        assertEq(proposalEngineOpts.distributionsRequireVote, true);
+        assertEq(
+            uint8(proposalEngineOpts.distributionsConfig),
+            uint8(ProposalStorage.DistributionsConfig.AllowedWithVote)
+        );
         assertEq(party.preciousListHash(), _hashPreciousList(preciousTokens, preciousTokenIds));
         assertEq(address(registry.getProvider(address(party))), address(provider));
         assertEq(provider.getMetadata(address(party), 0), customMetadata);

--- a/test/party/PartyGovernanceNFT.t.sol
+++ b/test/party/PartyGovernanceNFT.t.sol
@@ -540,7 +540,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
         uint40 newTimestamp = uint40(block.timestamp + 1);
@@ -568,7 +568,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: true,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
         address notHost = _randomAddress();
@@ -596,7 +596,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -632,7 +632,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -665,7 +665,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -693,7 +693,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -788,7 +788,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -923,7 +923,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -990,7 +990,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -1078,7 +1078,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -1148,7 +1148,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: false
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithoutVote
             })
         );
 
@@ -1179,7 +1179,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -1248,7 +1248,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -1318,7 +1318,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -1409,7 +1409,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -1480,7 +1480,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -1549,7 +1549,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 
@@ -1637,7 +1637,7 @@ contract PartyGovernanceNFTTest is PartyGovernanceNFTTestBase {
                 allowArbCallsToSpendPartyEth: false,
                 allowOperators: false,
                 // Needs to be true to set non-zero rageQuitTimestamp
-                distributionsRequireVote: true
+                distributionsConfig: ProposalStorage.DistributionsConfig.AllowedWithVote
             })
         );
 

--- a/test/party/PartyGovernanceUnit.t.sol
+++ b/test/party/PartyGovernanceUnit.t.sol
@@ -296,7 +296,9 @@ contract PartyGovernanceUnitTest is Test, TestUtils {
         uint256[] memory preciousTokenIds
     ) private returns (TestablePartyGovernance gov) {
         defaultGovernanceOpts.totalVotingPower = totalVotingPower;
-        defaultProposalEngineOpts.distributionsRequireVote = distributionsRequireVote;
+        defaultProposalEngineOpts.distributionsConfig = ProposalStorage.DistributionsConfig(
+            distributionsRequireVote ? 1 : 0
+        );
 
         return
             new TestablePartyGovernance(

--- a/test/utils/SetupPartyHelper.sol
+++ b/test/utils/SetupPartyHelper.sol
@@ -17,6 +17,7 @@ import { ERC721Receiver } from "../../contracts/tokens/ERC721Receiver.sol";
 import { MetadataRegistry } from "../../contracts/renderers/MetadataRegistry.sol";
 import { TokenDistributor } from "../../contracts/distribution/TokenDistributor.sol";
 import { OffChainSignatureValidator } from "../../contracts/signature-validators/OffChainSignatureValidator.sol";
+import { ProposalStorage } from "../../contracts/proposals/ProposalStorage.sol";
 
 /// @notice This contract provides a fully functioning party instance for testing.
 ///     Run setup from inheriting contract.
@@ -111,7 +112,9 @@ abstract contract SetupPartyHelper is TestUtils, ERC721Receiver {
         opts.governance.executionDelay = _EXECUTION_DELAY;
         opts.governance.passThresholdBps = 1000;
         opts.proposalEngine.allowArbCallsToSpendPartyEth = true;
-        opts.proposalEngine.distributionsRequireVote = true;
+        opts.proposalEngine.distributionsConfig = ProposalStorage
+            .DistributionsConfig
+            .AllowedWithVote;
         opts.governance.totalVotingPower = johnVotes + dannyVotes + steveVotes + thisVotes;
 
         address[] memory authorities = new address[](1);


### PR DESCRIPTION
A quick note here. I switched the `distributionsRequireVote` bool into the `distributionsConfig` enum. Enums are stored as `uint8` in storage (and bools are stored to take a whole byte when packed in storage in a struct). Therefore, the storage layout remains identical so the proposal execution engine will be backwards compatible. Enum values map to the previous boolean values.