### PR TITLE
feat: free first party card bonding curve

### DIFF
--- a/contracts/authorities/BondingCurveAuthority.sol
+++ b/contracts/authorities/BondingCurveAuthority.sol
@@ -26,6 +26,7 @@ contract BondingCurveAuthority {
     error SellZeroPartyCards();
     error DistributionsNotSupported();
     error NeedAtLeastOneHost();
+    error InvalidDiscount();
 
     event BondingCurvePartyCreated(
         Party indexed party,
@@ -157,6 +158,10 @@ contract BondingCurveAuthority {
         address[] memory authorities = new address[](1);
         authorities[0] = address(this);
 
+        if (partyOpts.firstCardDiscount > partyOpts.b) {
+            revert InvalidDiscount();
+        }
+
         _validateGovernanceOpts(partyOpts.opts);
 
         party = partyOpts.partyFactory.createParty(
@@ -202,6 +207,10 @@ contract BondingCurveAuthority {
     ) external payable returns (Party party) {
         address[] memory authorities = new address[](1);
         authorities[0] = address(this);
+
+        if (partyOpts.firstCardDiscount > partyOpts.b) {
+            revert InvalidDiscount();
+        }
 
         _validateGovernanceOpts(partyOpts.opts);
 
@@ -285,7 +294,7 @@ contract BondingCurveAuthority {
             amount,
             partyInfo.a,
             partyInfo.b,
-            0
+            partyInfo.firstCardDiscount
         );
         uint256 partyDaoFee = (bondingCurvePrice * partyDaoFeeBps) / BPS;
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
@@ -329,7 +338,7 @@ contract BondingCurveAuthority {
             1,
             partyInfo.a,
             partyInfo.b,
-            0
+            partyInfo.firstCardDiscount
         );
 
         emit PartyCardsBought(
@@ -374,7 +383,7 @@ contract BondingCurveAuthority {
             amount,
             partyInfo.a,
             partyInfo.b,
-            0
+            partyInfo.firstCardDiscount
         );
         uint256 partyDaoFee = (bondingCurvePrice * partyDaoFeeBps) / BPS;
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
@@ -430,7 +439,7 @@ contract BondingCurveAuthority {
             1,
             partyInfo.a,
             partyInfo.b,
-            0
+            partyInfo.firstCardDiscount
         );
 
         emit PartyCardsSold(
@@ -458,7 +467,7 @@ contract BondingCurveAuthority {
             amount,
             partyInfo.a,
             partyInfo.b,
-            0
+            partyInfo.firstCardDiscount
         );
         uint256 partyDaoFee = (bondingCurvePrice * partyDaoFeeBps) / BPS;
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
@@ -481,7 +490,8 @@ contract BondingCurveAuthority {
                 amount,
                 partyInfo.a,
                 partyInfo.b,
-                partyInfo.creatorFeeOn
+                partyInfo.creatorFeeOn,
+                partyInfo.firstCardDiscount
             );
     }
 
@@ -499,9 +509,10 @@ contract BondingCurveAuthority {
         uint80 amount,
         uint32 a,
         uint80 b,
-        bool creatorFeeOn
+        bool creatorFeeOn,
+        uint80 firstCardDiscount
     ) public view returns (uint256) {
-        uint256 bondingCurvePrice = _getBondingCurvePrice(supply, amount, a, b, 0);
+        uint256 bondingCurvePrice = _getBondingCurvePrice(supply, amount, a, b, firstCardDiscount);
         uint256 partyDaoFee = (bondingCurvePrice * partyDaoFeeBps) / BPS;
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
         uint256 creatorFee = (bondingCurvePrice * (creatorFeeOn ? creatorFeeBps : 0)) / BPS;

--- a/contracts/authorities/BondingCurveAuthority.sol
+++ b/contracts/authorities/BondingCurveAuthority.sol
@@ -94,6 +94,8 @@ contract BondingCurveAuthority {
         // The value of b in the bonding curve formula 1 ether * x ** 2 / a + b
         // used by the Party to price cards
         uint80 b;
+        // Discount when buying/selling the first card in the party
+        uint80 firstCardDiscount;
     }
 
     /// @notice Struct containing info stored for a party
@@ -110,6 +112,8 @@ contract BondingCurveAuthority {
         // The value of b in the bonding curve formula 1 ether * x ** 2 / a + b
         // used by the Party to price cards
         uint80 b;
+        // Discount when buying/selling the first card in the party
+        uint80 firstCardDiscount;
     }
 
     modifier onlyPartyDao() {
@@ -173,7 +177,8 @@ contract BondingCurveAuthority {
             supply: 0,
             creatorFeeOn: partyOpts.creatorFeeOn,
             a: partyOpts.a,
-            b: partyOpts.b
+            b: partyOpts.b,
+            firstCardDiscount: partyOpts.firstCardDiscount
         });
 
         emit BondingCurvePartyCreated(party, msg.sender, partyOpts);
@@ -220,7 +225,8 @@ contract BondingCurveAuthority {
             supply: 0,
             creatorFeeOn: partyOpts.creatorFeeOn,
             a: partyOpts.a,
-            b: partyOpts.b
+            b: partyOpts.b,
+            firstCardDiscount: partyOpts.firstCardDiscount
         });
 
         emit BondingCurvePartyCreated(party, msg.sender, partyOpts);
@@ -278,7 +284,8 @@ contract BondingCurveAuthority {
             partyInfo.supply,
             amount,
             partyInfo.a,
-            partyInfo.b
+            partyInfo.b,
+            0
         );
         uint256 partyDaoFee = (bondingCurvePrice * partyDaoFeeBps) / BPS;
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
@@ -321,7 +328,8 @@ contract BondingCurveAuthority {
             partyInfo.supply + amount - 1,
             1,
             partyInfo.a,
-            partyInfo.b
+            partyInfo.b,
+            0
         );
 
         emit PartyCardsBought(
@@ -365,7 +373,8 @@ contract BondingCurveAuthority {
             partyInfo.supply - amount,
             amount,
             partyInfo.a,
-            partyInfo.b
+            partyInfo.b,
+            0
         );
         uint256 partyDaoFee = (bondingCurvePrice * partyDaoFeeBps) / BPS;
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
@@ -420,7 +429,8 @@ contract BondingCurveAuthority {
             partyInfo.supply - amount,
             1,
             partyInfo.a,
-            partyInfo.b
+            partyInfo.b,
+            0
         );
 
         emit PartyCardsSold(
@@ -447,7 +457,8 @@ contract BondingCurveAuthority {
             partyInfo.supply - amount,
             amount,
             partyInfo.a,
-            partyInfo.b
+            partyInfo.b,
+            0
         );
         uint256 partyDaoFee = (bondingCurvePrice * partyDaoFeeBps) / BPS;
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
@@ -490,7 +501,7 @@ contract BondingCurveAuthority {
         uint80 b,
         bool creatorFeeOn
     ) public view returns (uint256) {
-        uint256 bondingCurvePrice = _getBondingCurvePrice(supply, amount, a, b);
+        uint256 bondingCurvePrice = _getBondingCurvePrice(supply, amount, a, b, 0);
         uint256 partyDaoFee = (bondingCurvePrice * partyDaoFeeBps) / BPS;
         uint256 treasuryFee = (bondingCurvePrice * treasuryFeeBps) / BPS;
         uint256 creatorFee = (bondingCurvePrice * (creatorFeeOn ? creatorFeeBps : 0)) / BPS;
@@ -510,8 +521,10 @@ contract BondingCurveAuthority {
         uint256 lowerSupply,
         uint256 amount,
         uint32 a,
-        uint80 b
+        uint80 b,
+        uint80 firstCardDiscount
     ) internal pure returns (uint256) {
+        uint256 discount = lowerSupply == 0 ? firstCardDiscount : 0;
         // Using the function 1 ether * x ** 2 / a + b
         uint256 amountSquared = amount * amount;
         return
@@ -525,7 +538,8 @@ contract BondingCurveAuthority {
                     6)) /
             uint256(a) +
             amount *
-            uint256(b);
+            uint256(b) -
+            discount;
     }
 
     /**

--- a/test/authorities/BondingCurveAuthority.t.sol
+++ b/test/authorities/BondingCurveAuthority.t.sol
@@ -101,7 +101,8 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
                 opts: opts,
                 creatorFeeOn: creatorFeeOn,
                 a: 50_000,
-                b: uint80(0.001 ether)
+                b: uint80(0.001 ether),
+                firstCardDiscount: 0
             });
 
         vm.deal(creator, initialPrice);
@@ -152,9 +153,8 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
         uint256 expectedTreasuryFee = (expectedBondingCurvePrice * TREASURY_FEE_BPS) / 1e4;
         uint256 expectedCreatorFee = (expectedBondingCurvePrice * CREATOR_FEE_BPS) / 1e4;
 
-        (address payable partyCreator, uint80 supply, bool creatorFeeOn, , ) = authority.partyInfos(
-            party
-        );
+        (address payable partyCreator, uint80 supply, bool creatorFeeOn, , , ) = authority
+            .partyInfos(party);
 
         assertEq(partyCreator, creator);
         assertTrue(creatorFeeOn);
@@ -181,7 +181,8 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
                 opts: opts,
                 creatorFeeOn: true,
                 a: 50_000,
-                b: uint80(0.001 ether)
+                b: uint80(0.001 ether),
+                firstCardDiscount: 0
             }),
             1
         );
@@ -200,7 +201,8 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
                 opts: opts,
                 creatorFeeOn: true,
                 a: 50_000,
-                b: uint80(0.001 ether)
+                b: uint80(0.001 ether),
+                firstCardDiscount: 0
             }),
             1
         );
@@ -217,7 +219,8 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
                 opts: opts,
                 creatorFeeOn: true,
                 a: 50_000,
-                b: uint80(0.001 ether)
+                b: uint80(0.001 ether),
+                firstCardDiscount: 0
             }),
             1
         );
@@ -233,7 +236,8 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
                 opts: opts,
                 creatorFeeOn: true,
                 a: 50_000,
-                b: uint80(0.001 ether)
+                b: uint80(0.001 ether),
+                firstCardDiscount: 0
             }),
             1
         );
@@ -242,9 +246,8 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
     function test_createParty_moreThanOnePartyCard() public {
         (Party party, address payable creator, ) = _createParty(5, true);
 
-        (address payable partyCreator, uint80 supply, bool creatorFeeOn, , ) = authority.partyInfos(
-            party
-        );
+        (address payable partyCreator, uint80 supply, bool creatorFeeOn, , , ) = authority
+            .partyInfos(party);
 
         assertEq(partyCreator, creator);
         assertTrue(creatorFeeOn);
@@ -265,28 +268,30 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
         vm.deal(creator, initialPrice);
         vm.prank(creator);
         vm.expectRevert(BondingCurveAuthority.ExistingParty.selector);
-        Party party = authority.createParty{ value: initialPrice }(
+        authority.createParty{ value: initialPrice }(
             BondingCurveAuthority.BondingCurvePartyOptions({
                 partyFactory: trickFactory,
                 partyImpl: partyImpl,
                 opts: opts,
                 creatorFeeOn: true,
                 a: 50_000,
-                b: uint80(0.001 ether)
+                b: uint80(0.001 ether),
+                firstCardDiscount: 0
             }),
             2
         );
 
         vm.prank(creator);
         vm.expectRevert(BondingCurveAuthority.ExistingParty.selector);
-        Party party2 = authority.createPartyWithMetadata{ value: initialPrice }(
+        authority.createPartyWithMetadata{ value: initialPrice }(
             BondingCurveAuthority.BondingCurvePartyOptions({
                 partyFactory: trickFactory,
                 partyImpl: partyImpl,
                 opts: opts,
                 creatorFeeOn: true,
                 a: 50_000,
-                b: uint80(0.001 ether)
+                b: uint80(0.001 ether),
+                firstCardDiscount: 0
             }),
             MetadataProvider(address(0)),
             "",
@@ -315,7 +320,8 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
                 opts: opts,
                 creatorFeeOn: false,
                 a: 50_000,
-                b: uint80(0.001 ether)
+                b: uint80(0.001 ether),
+                firstCardDiscount: 0
             }),
             metadataProvider,
             metadata,
@@ -349,7 +355,8 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
                 opts: opts,
                 creatorFeeOn: true,
                 a: 50_000,
-                b: uint80(0.001 ether)
+                b: uint80(0.001 ether),
+                firstCardDiscount: 0
             }),
             1
         );
@@ -362,7 +369,8 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
                 opts: opts,
                 creatorFeeOn: true,
                 a: 50_000,
-                b: uint80(0.001 ether)
+                b: uint80(0.001 ether),
+                firstCardDiscount: 0
             }),
             MetadataProvider(address(0)),
             "",
@@ -429,7 +437,7 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
 
         authority.buyPartyCards{ value: expectedPriceToBuy }(party, 10, address(0));
 
-        (, uint80 supply, , , ) = authority.partyInfos(party);
+        (, uint80 supply, , , , ) = authority.partyInfos(party);
 
         assertEq(party.balanceOf(buyer), 10);
         assertEq(
@@ -488,11 +496,7 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
         address buyer = _randomAddress();
         vm.deal(buyer, expectedPriceToBuy);
         vm.prank(buyer);
-        uint256[] memory tokenIds = authority.buyPartyCards{ value: expectedPriceToBuy }(
-            party,
-            3,
-            address(0)
-        );
+        authority.buyPartyCards{ value: expectedPriceToBuy }(party, 3, address(0));
         assertEq(buyer.balance, expectedCreatorFee); // got back creator fee
         assertEq(creator.balance, creatorBalanceBefore);
     }
@@ -605,7 +609,7 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
         }
 
         authority.sellPartyCards(party, tokenIds, 0);
-        (, uint80 supply, , , ) = authority.partyInfos(party);
+        (, uint80 supply, , , , ) = authority.partyInfos(party);
 
         assertEq(supply, 1);
         assertEq(party.balanceOf(buyer), 0);
@@ -627,13 +631,7 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
     }
 
     function test_sellPartyCards_revertIfTooMuchSlippage() public {
-        (
-            Party party,
-            address payable creator,
-            uint256 initialBalanceExcludingPartyDaoFee,
-            address buyer,
-            uint256 expectedBondingCurvePrice
-        ) = test_buyPartyCards_works();
+        (Party party, address payable creator, , address buyer, ) = test_buyPartyCards_works();
 
         uint256[] memory tokenIds = new uint256[](10);
         for (uint256 i = 0; i < 10; i++) tokenIds[i] = i + 2;
@@ -984,8 +982,6 @@ contract BondingCurveAuthorityTest is SetupPartyHelper {
         vm.assume(a > 0);
         vm.assume(amount < 200);
 
-        uint256 expectedBondingCurvePrice = 0;
-
         uint256 aggregatePrice = 0;
         for (uint i = 0; i < amount; i++) {
             aggregatePrice += authority.getBondingCurvePrice(previousSupply + i, 1, a, b);
@@ -1022,7 +1018,7 @@ contract MockBondingCurveAuthority is BondingCurveAuthority {
         uint32 a,
         uint80 b
     ) external pure returns (uint256) {
-        return super._getBondingCurvePrice(lowerSupply, amount, a, b);
+        return super._getBondingCurvePrice(lowerSupply, amount, a, b, 0);
     }
 }
 
@@ -1040,7 +1036,7 @@ contract TrickFactory is Test {
         IERC721[] memory,
         uint256[] memory,
         uint40
-    ) external returns (Party party) {
+    ) external view returns (Party party) {
         return Party(payable(contractAddressFrom(realFactory, vm.getNonce(realFactory) - 1)));
     }
 
@@ -1053,7 +1049,7 @@ contract TrickFactory is Test {
         uint40,
         MetadataProvider,
         bytes memory
-    ) external returns (Party party) {
+    ) external view returns (Party party) {
         return Party(payable(contractAddressFrom(realFactory, vm.getNonce(realFactory) - 1)));
     }
 


### PR DESCRIPTION
Adds functionality to the `BondingCurveAuthority` that enables setting a discount for the first party token. `firstCardDiscount = b` for the first party card to be free.